### PR TITLE
refactor(transpiler-core): replace estraverse with estree-walker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
       "devDependencies": {
         "@twada/benchmark-commits": "^0.3.1",
         "@types/convert-source-map": "^2.0.0",
-        "@types/estraverse": "^5.1.2",
         "@types/estree": "^1.0.1",
         "@types/multi-stage-sourcemap": "^0.3.0",
         "@types/node": "^20.0.0",
@@ -1514,15 +1513,6 @@
       "resolved": "https://registry.npmjs.org/@types/convert-source-map/-/convert-source-map-2.0.3.tgz",
       "integrity": "sha512-ag0BfJLZf6CQz8VIuRIEYQ5Ggwk/82uvTQf27RcpyDNbY0Vw49LIPqAxk5tqYfrCs9xDaIMvl4aj7ZopnYL8bA==",
       "dev": true
-    },
-    "node_modules/@types/estraverse": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/@types/estraverse/-/estraverse-5.1.7.tgz",
-      "integrity": "sha512-JRVtdKYZz7VkNp7hMC/WKoiZ8DS3byw20ZGoMZ1R8eBrBPIY7iBaDAS1zcrnXQCwK44G4vbXkimeU7R0VLG8UQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "*"
-      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1527,8 +1527,7 @@
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
@@ -3758,6 +3757,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -8258,13 +8258,21 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "estraverse": "^5.3.0"
+        "estree-walker": "^3.0.3"
       },
       "devDependencies": {
         "@types/estree": "^1.0.1",
         "acorn": "^8.10.0",
         "astring": "^1.8.6",
         "meriyah": "^4.3.7"
+      }
+    },
+    "packages/transpiler-core/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "packages/vitest-plugin-power-assert": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "devDependencies": {
     "@twada/benchmark-commits": "^0.3.1",
     "@types/convert-source-map": "^2.0.0",
-    "@types/estraverse": "^5.1.2",
     "@types/estree": "^1.0.1",
     "@types/multi-stage-sourcemap": "^0.3.0",
     "@types/node": "^20.0.0",

--- a/packages/transpiler-core/package.json
+++ b/packages/transpiler-core/package.json
@@ -33,7 +33,7 @@
     "package.json"
   ],
   "dependencies": {
-    "estraverse": "^5.3.0"
+    "estree-walker": "^3.0.3"
   },
   "devDependencies": {
     "@types/estree": "^1.0.1",

--- a/packages/transpiler-core/src/__tests__/assertion_visitor_test.mts
+++ b/packages/transpiler-core/src/__tests__/assertion_visitor_test.mts
@@ -4,7 +4,6 @@ import { AssertionVisitor, extractArea } from '../assertion-visitor.mjs';
 import { parseExpressionAt } from 'acorn';
 import type { Options as AcornOptions } from 'acorn';
 
-import type { Controller } from 'estraverse';
 import type { Node, CallExpression, Identifier, ImportDeclaration, VariableDeclaration } from 'estree';
 import type { Transformation } from '../transformation.mjs';
 
@@ -124,30 +123,14 @@ assert.ok(truthy);
   });
 
   describe('after #leaveArgument', () => {
-    let controller: Controller;
     let resultNode: CallExpression;
     let currentNode: Node;
 
     beforeEach(() => {
-      controller = {
-        path: () => ['body', 2, 'expression', 'arguments', 0],
-        current: () => callexp.arguments[0]
-      } as Controller;
       currentNode = callexp.arguments[0];
       assertionVisitor.enterArgument(currentNode);
-
-      // controller = {
-      //   path: () => ['body', 2, 'expression', 'arguments', 0],
-      //   current: () => callexp.arguments[0]
-      // } as Controller;
       assertionVisitor.enterNodeToBeCaptured(callexp.arguments[0]);
 
-      // controller = {
-      //   // parents: () => [callexp, expstmt, program],
-      //   parents: () => [callexp],
-      //   path: () => ['body', 2, 'expression', 'arguments', 0],
-      //   current: () => callexp.arguments[0]
-      // } as Controller;
       currentNode = callexp.arguments[0];
       const controllerLike = {
         currentNode,
@@ -189,7 +172,7 @@ assert.ok(truthy);
         // (truthy, 'arguments/0', 10)
         const args = resultNode.arguments;
         assert.equal(args.length, 2);
-        assert.equal(args[0], controller.current());
+        assert.equal(args[0], currentNode);
         assert.equal(args[1].type, 'Literal');
         assert.equal(args[1].value, 10);
       });
@@ -197,31 +180,15 @@ assert.ok(truthy);
   });
 
   describe('after #leave', () => {
-    // let controller: Controller;
     let resultNode: CallExpression;
     let currentNode: Node;
 
     beforeEach(() => {
-      // controller = {
-      //   path: () => ['body', 2, 'expression', 'arguments', 0],
-      //   current: () => callexp.arguments[0]
-      // } as Controller;
       currentNode = callexp.arguments[0];
       assertionVisitor.enterArgument(currentNode);
 
-      // controller = {
-      //   path: () => ['body', 2, 'expression', 'arguments', 0],
-      //   current: () => callexp.arguments[0]
-      // } as Controller;
       assertionVisitor.enterNodeToBeCaptured(callexp.arguments[0]);
 
-      // controller = {
-      //   // parents: () => [callexp, expstmt, program],
-      //   parents: () => [callexp],
-      //   path: () => ['body', 2, 'expression', 'arguments', 0],
-      //   current: () => callexp.arguments[0]
-      // } as Controller;
-      // assertionVisitor.leaveArgument(controller);
       currentNode = callexp.arguments[0];
       const controllerLike = {
         currentNode,
@@ -231,10 +198,6 @@ assert.ok(truthy);
       const astPath = ['body', 2, 'expression', 'arguments', 0];
       assertionVisitor.leaveArgument(controllerLike, astPath);
 
-      // controller = {
-      //   path: () => ['body', 2, 'expression'],
-      //   current: () => callexp
-      // } as Controller;
       currentNode = callexp;
       resultNode = assertionVisitor.leave(currentNode) as CallExpression;
     });

--- a/packages/transpiler-core/src/transpiler-core.mts
+++ b/packages/transpiler-core/src/transpiler-core.mts
@@ -1,9 +1,11 @@
-import { replace } from 'estraverse';
+// import { replace } from 'estraverse';
 import { Transformation } from './transformation.mjs';
 import { AssertionVisitor } from './assertion-visitor.mjs';
 import { nodeFactory, isScoped } from './node-factory.mjs';
 import { strict as assert } from 'node:assert';
-import type { Visitor, VisitorOption, Controller } from 'estraverse';
+// import type { Visitor, VisitorOption, Controller } from 'estraverse';
+import { walk } from 'estree-walker';
+
 import type {
   Node,
   Literal,
@@ -16,6 +18,21 @@ import type {
   SpreadElement
 } from 'estree';
 import type { Scoped } from './node-factory.mjs';
+import type { SyncHandler } from 'estree-walker';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type KeyValue = { [key: string]: any };
+
+type Visitor = {
+  enter?: SyncHandler;
+  leave?: SyncHandler;
+};
+type WalkerContext = {
+  skip: () => void;
+  remove: () => void;
+  replace: (node: Node) => void;
+};
+type NodeKey = string | number | symbol | null | undefined;
 
 export type TargetImportSpecifier = {
   source: string,
@@ -185,22 +202,57 @@ function createVisitor (ast: Node, options: EspowerOptions): Visitor {
     return isAssertionFunction(callee) || isAssertionMethod(callee);
   }
 
-  function isCalleeOfParentCallExpression (parentNode: Node | null, currentKey: string | number | null): boolean {
+  function isCalleeOfParentCallExpression (parentNode: Node | null, currentKey: NodeKey): boolean {
     return !!parentNode && parentNode.type === 'CallExpression' && currentKey === 'callee';
   }
 
+  const nodePathStack: NodeKey[] = [];
   const nodeToCapture = new WeakSet();
   const blockStack: Scoped[] = [];
   const transformation = new Transformation(blockStack);
   let decoratorFunctionIdent: Identifier | null = null;
   let assertionVisitor: AssertionVisitor | null = null;
-  let skipping = false;
+  // let skipping = false;
+
+  function popNodePathStackAndBlockStack (currentNode: Node, parentNode: Node | null, key: string | number | symbol | null | undefined, index: number | null | undefined): void {
+    if (parentNode && index !== null && typeof key === 'string' && isLastChild(parentNode, key, index)) {
+      nodePathStack.pop();
+    }
+    nodePathStack.pop();
+    if (isScoped(currentNode)) {
+      blockStack.pop();
+    }
+  }
+
+  function applyTransformationIfMatched (walkerContext: WalkerContext, currentNode: Node) {
+    if (transformation.isTarget(currentNode)) {
+      // apply transformation to currentNode (Scope)
+      transformation.apply(currentNode);
+      // replace currentNode with transformed one
+      walkerContext.replace(currentNode);
+    }
+  }
+
+  // estree-walker MEMO: port leave-side logic here since leave() will not be called when skip() is called
+  function skip (walkerContext: WalkerContext, currentNode: Node, parentNode: Node | null, key: string | number | symbol | null | undefined, index: number | null | undefined) {
+    applyTransformationIfMatched(walkerContext, currentNode);
+    popNodePathStackAndBlockStack(currentNode, parentNode, key, index);
+    walkerContext.skip();
+  }
 
   return {
-    enter: function (this: Controller, currentNode: Node, parentNode: Node | null): VisitorOption | Node | void {
-      const controller = this; // eslint-disable-line @typescript-eslint/no-this-alias
-      const astPath = controller.path();
-      const currentKey = astPath ? astPath[astPath.length - 1] : null;
+    // enter: function (this: Controller, currentNode: Node, parentNode: Node | null): VisitorOption | Node | void {
+    enter: function (this: WalkerContext, currentNode: Node, parentNode: Node | null, key: string | number | symbol | null | undefined, index: number | null | undefined): void {
+      const currentKey = index !== null ? index : key;
+      if (index !== null && index === 0) {
+        // add prop key on entering first child
+        nodePathStack.push(key);
+      }
+      nodePathStack.push(currentKey);
+      // const controller = this; // eslint-disable-line @typescript-eslint/no-this-alias
+      // const astPath = controller.path();
+      const astPath = ([] as NodeKey[]).concat(nodePathStack);
+      // const currentKey = astPath ? astPath[astPath.length - 1] : null;
       const controllerLike = {
         currentNode,
         parentNode,
@@ -213,9 +265,12 @@ function createVisitor (ast: Node, options: EspowerOptions): Visitor {
 
       if (assertionVisitor) {
         if (assertionVisitor.isNodeToBeSkipped(controllerLike)) {
-          skipping = true;
+          // skipping = true;
           // console.log(`##### skipping ${this.path().join('/')} #####`);
-          return controller.skip();
+          // estree-walker MEMO: leave() will not be called when skip() is called
+          skip(this, currentNode, parentNode, key, index);
+          // this.skip();
+          return;
         }
         if (!assertionVisitor.isCapturingArgument() && !isCalleeOfParentCallExpression(parentNode, currentKey)) {
           // entering argument
@@ -235,14 +290,16 @@ function createVisitor (ast: Node, options: EspowerOptions): Visitor {
             if (!(isAssertionModuleName(source))) {
               return undefined;
             }
-            this.skip();
+            skip(this, currentNode, parentNode, key, index);
+            // this.skip();
             // register local identifier(s) as assertion variable
             handleImportSpecifiers(currentNode);
             break;
           }
           case 'VariableDeclarator': {
             if (isEnhanceTargetRequire(currentNode.id, currentNode.init)) {
-              this.skip();
+              skip(this, currentNode, parentNode, key, index);
+              // this.skip();
               // register local identifier(s) as assertion variable
               registerAssertionVariables(currentNode.id);
             }
@@ -253,7 +310,8 @@ function createVisitor (ast: Node, options: EspowerOptions): Visitor {
               return undefined;
             }
             if (isEnhanceTargetRequire(currentNode.left, currentNode.right)) {
-              this.skip();
+              skip(this, currentNode, parentNode, key, index);
+              // this.skip();
               // register local identifier(s) as assertion variable
               registerAssertionVariables(currentNode.left);
             }
@@ -266,7 +324,7 @@ function createVisitor (ast: Node, options: EspowerOptions): Visitor {
               // assert(...args) looks like one argument syntactically, however there are two or more arguments actually.
               // power-assert works at the syntax level so it cannot handle SpreadElement that appears immediately beneath assert.
               if (currentNode.arguments.some(isSpreadElement)) {
-                this.skip();
+                skip(this, currentNode, parentNode, key, index);
                 break;
               }
 
@@ -290,11 +348,14 @@ function createVisitor (ast: Node, options: EspowerOptions): Visitor {
       }
       return undefined;
     },
-    leave: function (this: Controller, currentNode: Node, parentNode: Node | null): VisitorOption | Node | void {
+    // leave: function (this: Controller, currentNode: Node, parentNode: Node | null): VisitorOption | Node | void {
+    leave: function (this: WalkerContext, currentNode: Node, parentNode: Node | null, key: string | number | symbol | null | undefined, index: number | null | undefined): void {
       try {
-        const controller = this; // eslint-disable-line @typescript-eslint/no-this-alias
-        const astPath = controller.path();
-        const currentKey = astPath ? astPath[astPath.length - 1] : null;
+        // const controller = this; // eslint-disable-line @typescript-eslint/no-this-alias
+        // const astPath = controller.path();
+        const astPath = ([] as NodeKey[]).concat(nodePathStack);
+        // const currentKey = astPath ? astPath[astPath.length - 1] : null;
+        const currentKey = index !== null ? index : key;
         const controllerLike = {
           currentNode,
           parentNode,
@@ -306,15 +367,16 @@ function createVisitor (ast: Node, options: EspowerOptions): Visitor {
           // apply transformation to currentNode (Scope)
           transformation.apply(currentNode);
           // replace currentNode with transformed one
-          return currentNode;
+          this.replace(currentNode);
+          return undefined;
         }
         if (!assertionVisitor) {
           return undefined;
         }
-        if (skipping) {
-          skipping = false;
-          return undefined;
-        }
+        // if (skipping) {
+        //   skipping = false;
+        //   return undefined;
+        // }
         // console.log(`##### leave ${this.path().join('/')} #####`);
         if (nodeToCapture.has(currentNode)) {
           // leaving assertion
@@ -322,7 +384,9 @@ function createVisitor (ast: Node, options: EspowerOptions): Visitor {
           // console.log(`##### leave assertion ${this.path().join('/')} #####`);
           const resultTree = assertionVisitor.leave(currentNode);
           assertionVisitor = null;
-          return resultTree;
+          // return resultTree;
+          this.replace(resultTree);
+          return;
         }
         if (!assertionVisitor.isCapturingArgument()) {
           return undefined;
@@ -330,21 +394,28 @@ function createVisitor (ast: Node, options: EspowerOptions): Visitor {
         if (assertionVisitor.isLeavingArgument(currentNode)) {
           // capturing whole argument on leaving argument
           assert(astPath !== null, 'astPath should not be null');
-          return assertionVisitor.leaveArgument(controllerLike, astPath);
+          // return assertionVisitor.leaveArgument(controllerLike, astPath);
+          this.replace(assertionVisitor.leaveArgument(controllerLike, astPath));
+          return;
         } else if (assertionVisitor.isNodeToBeCaptured(controllerLike)) {
           // capturing intermediate Node
           // console.log(`##### capture value ${this.path().join('/')} #####`);
           assert(astPath !== null, 'astPath should not be null');
-          return assertionVisitor.leaveNodeToBeCaptured(currentNode, astPath);
+          // return assertionVisitor.leaveNodeToBeCaptured(currentNode, astPath);
+          this.replace(assertionVisitor.leaveNodeToBeCaptured(currentNode, astPath));
+          return;
         }
         return undefined;
       } finally {
-        if (isScoped(currentNode)) {
-          blockStack.pop();
-        }
+        popNodePathStackAndBlockStack(currentNode, parentNode, key, index);
       }
     }
   };
+}
+
+function isLastChild (parentNode: Node, currentKey: string, index: number | null | undefined): boolean {
+  const parent = parentNode as KeyValue;
+  return parent[currentKey].length - 1 === index;
 }
 
 function createPowerAssertImports ({ transformation, currentNode, runtime }: { transformation: Transformation, currentNode: Node, runtime: string }): Identifier {
@@ -359,7 +430,10 @@ function createPowerAssertImports ({ transformation, currentNode, runtime }: { t
 }
 
 export function espowerAst (ast: Node, options: EspowerOptions): Node {
-  return replace(ast, createVisitor(ast, options));
+  const modifiedAst = walk(ast, createVisitor(ast, options));
+  assert(modifiedAst !== null, 'modifiedAst should not be null');
+  return modifiedAst;
+  // return replace(ast, createVisitor(ast, options));
 }
 
 export type DefaultEspowerOptions = {


### PR DESCRIPTION
Replace estraverse with [estree-walker](https://github.com/Rich-Harris/estree-walker) which has resistance to spec changes.

- [Rich-Harris/estree-walker: Traverse an ESTree-compliant AST](https://github.com/Rich-Harris/estree-walker)

Getting a bit faster:
```
finish benchmark of main-branch(main) x 11,636 ops/sec ±1.67% (91 runs sampled)
finish benchmark of estree-walker-branch(estree-walker) x 12,804 ops/sec ±1.01% (97 runs sampled)
finish suite: fastest is [estree-walker-branch(estree-walker)]
```
