### PR TITLE
Adjust CallExpression address if callee is Identifier or non-computed MemberExpression

### DIFF
--- a/packages/integration-tests/src/__tests__/integration_test.mts
+++ b/packages/integration-tests/src/__tests__/integration_test.mts
@@ -213,6 +213,39 @@ assert(inner().exact())
 
 false == true
 `);
+
+    ptest('method callee is non-computed MemberExpression', (transpiledCode) => {
+      const obj = {
+        method () { return false; }
+      };
+      eval(transpiledCode);
+    }, `
+
+assert(obj.method())
+       |   |
+       |   false
+       Object{method:function@method}
+
+false == true
+`);
+
+    ptest('method callee is non-computed MemberExpression that returns function then invoke immediately', (transpiledCode) => {
+      const obj = {
+        method () { return () => () => false; }
+      };
+      eval(transpiledCode);
+    }, `
+
+assert(obj.method()()())
+       |   |       | |
+       |   |       | false
+       |   |       function@anonymous
+       |   function@anonymous
+       Object{method:function@method}
+
+false == true
+`);
+
     ptest('method callee is computed MemberExpression', (transpiledCode) => {
       const methodName = 'method';
       const obj = {

--- a/packages/integration-tests/src/__tests__/integration_test.mts
+++ b/packages/integration-tests/src/__tests__/integration_test.mts
@@ -179,8 +179,8 @@ false == true
     }, `
 
 assert(inner())
-            |
-            false
+       |
+       false
 
 false == true
 `);
@@ -191,10 +191,10 @@ false == true
     }, `
 
 assert(outer()()())
-            | | |
-            | | false
-            | function@anonymous
-            function@anonymous
+       |      | |
+       |      | false
+       |      function@anonymous
+       function@anonymous
 
 false == true
 `);
@@ -207,9 +207,9 @@ false == true
     }, `
 
 assert(inner().exact())
-            |       |
-            |       false
-            Object{exact:function@exact}
+       |       |
+       |       false
+       Object{exact:function@exact}
 
 false == true
 `);

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -71,11 +71,11 @@ Then you will see the power-assert output.
     AssertionError [ERR_ASSERTION]:
 
     assert(ary.indexOf(zero) === two)
-           |          ||     |   |
-           |          ||     |   2
-           |          ||     false
-           |          |0
-           |          0
+           |   |       |     |   |
+           |   |       |     |   2
+           |   |       |     false
+           |   |       0
+           |   0
            [0,1,2]
 
     0 === 2

--- a/packages/swc-plugin-power-assert/src/lib.rs
+++ b/packages/swc-plugin-power-assert/src/lib.rs
@@ -435,7 +435,27 @@ impl TransformVisitor {
                     _ => Utf8Pos(expr.span_lo().to_u32() - assertion_start_pos.to_u32())
                 }
             },
-            Expr::Call(CallExpr{ callee, .. }) => self.search_pos_for("(", &callee.span(), assertion_start_pos),
+            Expr::Call(CallExpr{ callee, .. }) => {
+                match callee {
+                    Callee::Expr(callee_expr) => {
+                        match callee_expr.as_ref() {
+                            Expr::Ident(Ident { span, .. }) => {
+                                // for callee like `foo()`, foo's span is used
+                                Utf8Pos(span.span_lo().to_u32() - assertion_start_pos.to_u32())
+                            },
+                            Expr::Member(MemberExpr{ prop, .. }) => {
+                                match prop {
+                                    // for callee like `foo.bar()`, bar's span is used
+                                    MemberProp::Ident(Ident { span, .. }) => Utf8Pos(span.lo.to_u32() - assertion_start_pos.to_u32()),
+                                    _ => self.search_pos_for("(", &callee.span(), assertion_start_pos)
+                                }
+                            },
+                            _ => self.search_pos_for("(", &callee.span(), assertion_start_pos)
+                        }
+                    },
+                    _ => self.search_pos_for("(", &callee.span(), assertion_start_pos)
+                }
+            },
             // estree's LogicalExpression is mapped to BinaryExpression in swc
             Expr::Bin(BinExpr{ left, op, ..}) => self.search_pos_for(op.as_str(), &left.span(), assertion_start_pos),
             Expr::Assign(AssignExpr{ left, op, .. }) => self.search_pos_for(op.as_str(), &left.span(), assertion_start_pos),

--- a/packages/swc-plugin-power-assert/src/lib.rs
+++ b/packages/swc-plugin-power-assert/src/lib.rs
@@ -435,25 +435,14 @@ impl TransformVisitor {
                     _ => Utf8Pos(expr.span_lo().to_u32() - assertion_start_pos.to_u32())
                 }
             },
-            Expr::Call(CallExpr{ callee, .. }) => {
-                match callee {
-                    Callee::Expr(callee_expr) => {
-                        match callee_expr.as_ref() {
-                            Expr::Ident(Ident { span, .. }) => {
-                                // for callee like `foo()`, foo's span is used
-                                Utf8Pos(span.span_lo().to_u32() - assertion_start_pos.to_u32())
-                            },
-                            Expr::Member(MemberExpr{ prop, .. }) => {
-                                match prop {
-                                    // for callee like `foo.bar()`, bar's span is used
-                                    MemberProp::Ident(Ident { span, .. }) => Utf8Pos(span.lo.to_u32() - assertion_start_pos.to_u32()),
-                                    _ => self.search_pos_for("(", &callee.span(), assertion_start_pos)
-                                }
-                            },
-                            _ => self.search_pos_for("(", &callee.span(), assertion_start_pos)
-                        }
-                    },
-                    _ => self.search_pos_for("(", &callee.span(), assertion_start_pos)
+            Expr::Call(CallExpr{ callee: Callee::Expr(callee_expr), .. }) => {
+                match callee_expr.as_ref() {
+                    // for callee like `foo()`, foo's span is used
+                    Expr::Ident(Ident { span, .. }) => Utf8Pos(span.lo.to_u32() - assertion_start_pos.to_u32()),
+                    // for callee like `foo.bar()`, bar's span is used
+                    Expr::Member(MemberExpr{ prop: MemberProp::Ident(Ident { span, .. }), .. }) => Utf8Pos(span.lo.to_u32() - assertion_start_pos.to_u32()),
+                    // otherwise, span of opening parenthesis is used
+                    _ => self.search_pos_for("(", &callee_expr.span(), assertion_start_pos)
                 }
             },
             // estree's LogicalExpression is mapped to BinaryExpression in swc

--- a/packages/transpiler-core/fixtures/ArrayExpression/expected.mjs
+++ b/packages/transpiler-core/fixtures/ArrayExpression/expected.mjs
@@ -10,7 +10,7 @@ import {_power_} from "@power-assert/runtime";
     binexp: "==="
   });
   const _parg2 = _pasrt2.recorder(0);
-  _pasrt2.run(_parg2.rec(_parg2.tap(typeof _parg2.tap([_parg2.tap([_parg2.tap(_parg2.tap(foo, 16).bar, 20), _parg2.tap(baz(_parg2.tap(moo, 29)), 28)], 15), _parg2.tap(+_parg2.tap(fourStr, 38), 36)], 14), 7, {
+  _pasrt2.run(_parg2.rec(_parg2.tap(typeof _parg2.tap([_parg2.tap([_parg2.tap(_parg2.tap(foo, 16).bar, 20), _parg2.tap(baz(_parg2.tap(moo, 29)), 25)], 15), _parg2.tap(+_parg2.tap(fourStr, 38), 36)], 14), 7, {
     hint: "left"
   }) === _parg2.tap('number', 51, {
     hint: "right"

--- a/packages/transpiler-core/fixtures/CallExpression/expected.mjs
+++ b/packages/transpiler-core/fixtures/CallExpression/expected.mjs
@@ -6,7 +6,7 @@ describe('description', () => {
     const _pasrt1 = _power_(assert, null, "assert(func())");
     const _parg1 = _pasrt1.recorder(0);
     const func = () => false;
-    _pasrt1.run(_parg1.rec(func(), 11));
+    _pasrt1.run(_parg1.rec(func(), 7));
   });
   it('method', () => {
     const _pasrt2 = _power_(assert, null, "assert(obj.method())");
@@ -14,7 +14,7 @@ describe('description', () => {
     const obj = {
       method: () => false
     };
-    _pasrt2.run(_parg2.rec(_parg2.tap(obj, 7).method(), 17));
+    _pasrt2.run(_parg2.rec(_parg2.tap(obj, 7).method(), 11));
   });
   it('computed method', () => {
     const _pasrt3 = _power_(assert, null, "assert(obj[methodName]())");

--- a/packages/transpiler-core/fixtures/ClassScope/expected.mjs
+++ b/packages/transpiler-core/fixtures/ClassScope/expected.mjs
@@ -8,4 +8,4 @@ class Dog {
   }
 }
 const d = new Dog();
-_pasrt1.run(_parg1.rec(_parg1.tap(d, 7).say(), 12));
+_pasrt1.run(_parg1.rec(_parg1.tap(d, 7).say(), 9));

--- a/packages/transpiler-core/fixtures/ConditionalExpression/expected.mjs
+++ b/packages/transpiler-core/fixtures/ConditionalExpression/expected.mjs
@@ -13,7 +13,7 @@ import {_power_} from "@power-assert/runtime";
 {
   const _pasrt3 = _power_(assert, null, "assert(foo() ? bar.baz : +goo)");
   const _parg3 = _pasrt3.recorder(0);
-  _pasrt3.run(_parg3.rec(_parg3.tap(foo(), 10) ? _parg3.tap(_parg3.tap(bar, 15).baz, 19) : _parg3.tap(+_parg3.tap(goo, 26), 25), 13));
+  _pasrt3.run(_parg3.rec(_parg3.tap(foo(), 7) ? _parg3.tap(_parg3.tap(bar, 15).baz, 19) : _parg3.tap(+_parg3.tap(goo, 26), 25), 13));
 }
 {
   const _pasrt4 = _power_(assert.equal, assert, "assert.equal(foo ? bar : baz, falsy ? truthy : truthy ? anotherFalsy : truthy)");

--- a/packages/transpiler-core/fixtures/Literal/expected.mjs
+++ b/packages/transpiler-core/fixtures/Literal/expected.mjs
@@ -38,7 +38,7 @@ import {_power_} from "@power-assert/runtime";
 {
   const _pasrt7 = _power_(assert, null, "assert(/^not/.exec(str))");
   const _parg12 = _pasrt7.recorder(0);
-  _pasrt7.run(_parg12.rec(_parg12.tap(/^not/, 7).exec(_parg12.tap(str, 19)), 18));
+  _pasrt7.run(_parg12.rec(_parg12.tap(/^not/, 7).exec(_parg12.tap(str, 19)), 14));
 }
 {
   const _pasrt8 = _power_(assert, null, "assert(0b111110111)");

--- a/packages/transpiler-core/fixtures/ObjectExpression/expected.mjs
+++ b/packages/transpiler-core/fixtures/ObjectExpression/expected.mjs
@@ -16,7 +16,7 @@ import {_power_} from "@power-assert/runtime";
     name: _parg2.tap(nameOf(_parg2.tap({
       firstName: _parg2.tap(first, 50),
       lastName: _parg2.tap(last, 67)
-    }, 38)), 37)
+    }, 38)), 31)
   }, 9), 7));
 }
 {

--- a/packages/transpiler-core/fixtures/Property/expected.mjs
+++ b/packages/transpiler-core/fixtures/Property/expected.mjs
@@ -12,14 +12,14 @@ import {_power_} from "@power-assert/runtime";
   const _pasrt2 = _power_(assert, null, "assert({[ 'prop_' + foo() ]: 42})");
   const _parg3 = _pasrt2.recorder(0);
   _pasrt2.run(_parg3.rec({
-    [_parg3.tap(_parg3.tap('prop_', 10) + _parg3.tap(foo(), 23), 18)]: _parg3.tap(42, 29)
+    [_parg3.tap(_parg3.tap('prop_', 10) + _parg3.tap(foo(), 20), 18)]: _parg3.tap(42, 29)
   }, 7));
 }
 {
   const _pasrt3 = _power_(assert, null, "assert({[`prop_${generate(seed)}`]: foo})");
   const _parg4 = _pasrt3.recorder(0);
   _pasrt3.run(_parg4.rec({
-    [_parg4.tap(`prop_${_parg4.tap(generate(_parg4.tap(seed, 26)), 25)}`, 9)]: _parg4.tap(foo, 36)
+    [_parg4.tap(`prop_${_parg4.tap(generate(_parg4.tap(seed, 26)), 17)}`, 9)]: _parg4.tap(foo, 36)
   }, 7));
 }
 {

--- a/packages/transpiler-core/fixtures/SequenceExpression/expected.mjs
+++ b/packages/transpiler-core/fixtures/SequenceExpression/expected.mjs
@@ -18,7 +18,7 @@ _pasrt1.run(_parg1.rec((_parg1.tap(2, 8), _parg1.tap(1, 11), _parg1.tap(0, 14)))
 _pasrt2.run(_parg2.rec((_parg2.tap(foo, 8), _parg2.tap(bar, 13)) === _parg2.tap(baz, 22, {
   hint: "right"
 }), 18));
-_pasrt3.run(_parg3.rec(toto((_parg3.tap(tata, 13), _parg3.tap(titi, 19))), 11));
+_pasrt3.run(_parg3.rec(toto((_parg3.tap(tata, 13), _parg3.tap(titi, 19))), 7));
 _pasrt4.run(_parg4.rec((_parg4.tap(foo, 8), (_parg4.tap(bar, 14), _parg4.tap(baz, 19)))));
 _pasrt5.run(_parg5.rec((((((_parg5.tap(foo, 12), _parg5.tap(bar, 17)), _parg5.tap(baz, 23)), _parg5.tap(toto, 29)), _parg5.tap(tata, 36)), _parg5.tap(titi, 43))));
 _pasrt6.run(_parg6.rec((_parg6.tap(y = _parg6.tap(x, 12), 10), _parg6.tap(z, 15))));

--- a/packages/transpiler-core/fixtures/SpreadElement/expected.mjs
+++ b/packages/transpiler-core/fixtures/SpreadElement/expected.mjs
@@ -3,7 +3,7 @@ import {_power_} from "@power-assert/runtime";
 {
   const _pasrt1 = _power_(assert, null, "assert(hello(...names))");
   const _parg1 = _pasrt1.recorder(0);
-  _pasrt1.run(_parg1.rec(hello(..._parg1.tap(names, 16)), 12));
+  _pasrt1.run(_parg1.rec(hello(..._parg1.tap(names, 16)), 7));
 }
 {
   const _pasrt2 = _power_(assert, null, "assert([head, ...tail].length)");
@@ -13,7 +13,7 @@ import {_power_} from "@power-assert/runtime";
 {
   const _pasrt3 = _power_(assert, null, "assert(f(head, ...iter(), ...[foo, bar]))");
   const _parg3 = _pasrt3.recorder(0);
-  _pasrt3.run(_parg3.rec(f(_parg3.tap(head, 9), ..._parg3.tap(iter(), 22), ..._parg3.tap([_parg3.tap(foo, 30), _parg3.tap(bar, 35)], 29)), 8));
+  _pasrt3.run(_parg3.rec(f(_parg3.tap(head, 9), ..._parg3.tap(iter(), 18), ..._parg3.tap([_parg3.tap(foo, 30), _parg3.tap(bar, 35)], 29)), 7));
 }
 {
   assert(...iter());

--- a/packages/transpiler-core/fixtures/TaggedTemplateExpression/expected.mjs
+++ b/packages/transpiler-core/fixtures/TaggedTemplateExpression/expected.mjs
@@ -8,4 +8,4 @@ const _pasrt3 = _power_(assert, null, "assert(fn`driver ${bob.name}, navigator $
 const _parg3 = _pasrt3.recorder(0);
 _pasrt1.run(_parg1.rec(fn`a${_parg1.tap(1, 13)}`, 7));
 _pasrt2.run(_parg2.rec(fn`a${_parg2.tap(foo, 13)}b${_parg2.tap(bar, 20)}c${_parg2.tap(baz, 27)}`, 7));
-_pasrt3.run(_parg3.rec(fn`driver ${_parg3.tap(_parg3.tap(bob, 19).name, 23)}, navigator ${_parg3.tap(_parg3.tap(alice, 42).getName(), 55)}`, 7));
+_pasrt3.run(_parg3.rec(fn`driver ${_parg3.tap(_parg3.tap(bob, 19).name, 23)}, navigator ${_parg3.tap(_parg3.tap(alice, 42).getName(), 48)}`, 7));


### PR DESCRIPTION
Adjust CallExpression address if callee is Identifier or non-computed MemberExpression

before:
```
    assert(ary.indexOf(zero) === two)
           |          ||     |   |
           |          ||     |   2
           |          ||     false
           |          |0
           |          0
           [0,1,2]
```

after:
```
    assert(ary.indexOf(zero) === two)
           |   |       |     |   |
           |   |       |     |   2
           |   |       |     false
           |   |       0
           |   0
           [0,1,2]

```



also, dealing with edge cases
```
const obj = {
  method () { return () => () => false; }
};

assert(obj.method()()())
       |   |       | |
       |   |       | false
       |   |       function@anonymous
       |   function@anonymous
       Object{method:function@method}
```
