### PR TITLE
refactor(transpiler): Update acorn and astring for import attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2734,15 +2734,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-import-attributes": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "acorn": "^8"
-      }
-    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -3006,12 +2997,6 @@
       "bin": {
         "astring": "bin/astring"
       }
-    },
-    "node_modules/astring-import-attributes": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/astring-import-attributes/-/astring-import-attributes-0.1.0.tgz",
-      "integrity": "sha512-iL1ERzZtUY8u3SHUpvczrV42R355PB0SstEiiBkj5IMPqm9oUSwB67EMWAqJKke29gRESNR/lxUDeAbhxmwPwQ==",
-      "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -9693,10 +9678,8 @@
       "license": "MIT",
       "dependencies": {
         "@power-assert/transpiler-core": "^0.4.1",
-        "acorn": "^8.10.0",
-        "acorn-import-attributes": "^1.9.5",
-        "astring": "^1.8.6",
-        "astring-import-attributes": "^0.1.0",
+        "acorn": "^8.14.0",
+        "astring": "^1.9.0",
         "convert-source-map": "^2.0.0",
         "multi-stage-sourcemap": "^0.3.1",
         "source-map": "^0.7.4"

--- a/packages/transpiler/package.json
+++ b/packages/transpiler/package.json
@@ -43,10 +43,8 @@
   ],
   "dependencies": {
     "@power-assert/transpiler-core": "^0.4.1",
-    "acorn": "^8.10.0",
-    "acorn-import-attributes": "^1.9.5",
-    "astring": "^1.8.6",
-    "astring-import-attributes": "^0.1.0",
+    "acorn": "^8.14.0",
+    "astring": "^1.9.0",
     "convert-source-map": "^2.0.0",
     "multi-stage-sourcemap": "^0.3.1",
     "source-map": "^0.7.4"

--- a/packages/transpiler/src/@types/acorn-import-attributes.d.mts
+++ b/packages/transpiler/src/@types/acorn-import-attributes.d.mts
@@ -1,1 +1,0 @@
-declare module 'acorn-import-attributes';

--- a/packages/transpiler/src/parse-unparse.mts
+++ b/packages/transpiler/src/parse-unparse.mts
@@ -1,7 +1,5 @@
-import { Parser } from 'acorn';
-import { importAttributes } from 'acorn-import-attributes';
-import { generate, GENERATOR } from 'astring';
-import { astringImportAttributes } from 'astring-import-attributes';
+import { parse } from 'acorn';
+import { generate } from 'astring';
 import { SourceMapGenerator } from 'source-map';
 import { fromJSON, fromObject, fromMapFileSource, fromSource } from 'convert-source-map';
 import { transfer } from 'multi-stage-sourcemap';
@@ -20,7 +18,7 @@ export type CodeWithSourceMapConverter = {
 };
 
 export async function transpileWith (transpile: TranspileAstFunc, code: string, filePathOrUrl?: string): Promise<CodeWithSourceMapConverter> {
-  const ast: Node = Parser.extend(importAttributes).parse(code, {
+  const ast: Node = parse(code, {
     sourceType: 'module',
     ecmaVersion: 2024,
     locations: true, // true for SourceMap
@@ -32,7 +30,6 @@ export async function transpileWith (transpile: TranspileAstFunc, code: string, 
     file: filePathOrUrl
   });
   const transpiledCode = generate(modifiedAst, {
-    generator: astringImportAttributes(GENERATOR),
     sourceMap: smg
   });
 


### PR DESCRIPTION
Remove `acorn-import-attributes` and `astring-import-attributes` from dependencies since `acorn` and `astring` support import attributes by default.