### PR TITLE
chore: fix example rollup config warnings

### DIFF
--- a/packages/rollup-plugin-power-assert/rollup.config.power.mjs
+++ b/packages/rollup-plugin-power-assert/rollup.config.power.mjs
@@ -18,6 +18,11 @@ export default {
       constBindings: true
     }
   },
+  external: [
+    'node:test',
+    'node:assert/strict',
+    '@power-assert/runtime'
+  ],
   plugins: [
     // externals({
     //   // strip 'node:' prefix


### PR DESCRIPTION
## Summary
This PR fixes the `example` target in `rollup-plugin-power-assert`, where rollup bundler warns about referenced external dependencies that should not be bundled.

## Changes
Specify the warned dependencies as `external` in rollup config

### Before
```
examples/bowling.test.mjs → tmp...
(!) Unresolved dependencies
https://rollupjs.org/troubleshooting/#warning-treating-module-as-external-dependency
node:test (imported by "examples/bowling.test.mjs")
node:assert/strict (imported by "examples/bowling.test.mjs")
@power-assert/runtime (imported by "examples/bowling.test.mjs")
created tmp in 54ms
# ... snipped ...
```

### After
```
examples/bowling.test.mjs → tmp...
created tmp in 54ms
# ... snipped ...
```

