### PR TITLE
ci: release process modernization Phase 0 (groundwork)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      # avoid freshly published versions (supply chain attack mitigation)
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 
@@ -17,18 +20,21 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: ${{ matrix.node-version }}
+        # npm cache is acceptable here (non-release CI); release workflow must not use caching
         cache: 'npm'
     - run: npm ci
     - run: npm run lint
     - run: npm run test:dev
 
     - name: Setup Rust
-      uses: dtolnay/rust-toolchain@1.95.0
+      uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b # 1.95.0
       with:
         targets: wasm32-wasip1
     - run: npm run build:dist

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,22 @@
+name: Zizmor
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # for SARIF upload to code scanning
+      actions: read
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2

--- a/packages/esbuild-plugin-power-assert/package.json
+++ b/packages/esbuild-plugin-power-assert/package.json
@@ -1,6 +1,7 @@
 {
   "name": "esbuild-plugin-power-assert",
   "version": "0.0.0",
+  "private": true,
   "description": "power-assert esbuild plugin",
   "author": {
     "name": "Takuto WADA",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,6 +1,8 @@
+# Changelog
+
 ## [0.6.0](https://github.com/twada/power-assert-monorepo/releases/tag/node-0.6.0) (2025-07-01)
 
-#### Features
+### Features
 
 * [feat: "stepwise" assertion format for LLM-friendly output](https://github.com/twada/power-assert-monorepo/pull/23)
 
@@ -8,24 +10,24 @@
 ## [0.5.0](https://github.com/twada/power-assert-monorepo/releases/tag/node-v0.5.0) (2025-06-10)
 
 
-#### Features
+### Features
 
 * [Support direct TypeScript test execution with Node.js's Type stripping feature](https://github.com/twada/power-assert-monorepo/pull/22)
 
 
-#### Breaking Changes
+### Breaking Changes
 
 * set Node minimum version to v22.14.0, the version where `findPackageJSON` is introduced ([9d4db06f](https://github.com/twada/power-assert-monorepo/commit/9d4db06f54134ee0e56f132c8063aa21649c4f4f))
 
 
-### [0.4.2](https://github.com/twada/power-assert-monorepo/releases/tag/node-v0.4.2) (2024-12-09)
+## [0.4.2](https://github.com/twada/power-assert-monorepo/releases/tag/node-v0.4.2) (2024-12-09)
 
-#### Bug Fixes
+### Bug Fixes
 
   * [fix] fix regression introduced in ec23da61f4 ([329f6d1e](https://github.com/twada/power-assert-monorepo/commit/329f6d1edb8840744dc9478c6b0be521b5e5d9e1))
 
 
-### [0.4.1](https://github.com/twada/power-assert-monorepo/releases/tag/node-v0.4.1) (2024-08-23)
+## [0.4.1](https://github.com/twada/power-assert-monorepo/releases/tag/node-v0.4.1) (2024-08-23)
 
   * [refactor] [rename esm-loader.mts to hooks.mts](https://github.com/twada/power-assert-monorepo/commit/ec23da61f484d18aa508f31b4b8a6964ea8afe11)
 
@@ -41,7 +43,7 @@
 ## [0.3.0](https://github.com/twada/power-assert-monorepo/releases/tag/node-v0.3.0) (2024-05-31)
 
 
-#### Breaking Changes
+### Breaking Changes
 
 - Update Node.js version requirement to `>=20.6.0` ([cd618d17](https://github.com/twada/power-assert-monorepo/commit/cd618d1749cad6df954956de00492dfeb9afa397))
 
@@ -49,7 +51,7 @@
 ## [0.2.0](https://github.com/twada/power-assert-monorepo/releases/tag/node-v0.2.0) (2024-05-20)
 
 
-#### Features
+### Features
 
 - [Support node `--import` flag](https://github.com/twada/power-assert-monorepo/pull/8)
 - [Rename @power-assert/esm to @power-assert/node](https://github.com/twada/power-assert-monorepo/pull/9)

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/twada/power-assert-monorepo/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/twada/power-assert-monorepo.git",
+    "url": "git+https://github.com/twada/power-assert-monorepo.git",
     "directory": "packages/node"
   },
   "license": "MIT",

--- a/packages/rollup-plugin-power-assert/CHANGELOG.md
+++ b/packages/rollup-plugin-power-assert/CHANGELOG.md
@@ -1,11 +1,13 @@
+# Changelog
+
 ## [0.2.0](https://github.com/twada/power-assert-monorepo/releases/tag/rollup-plugin-power-assert-v0.2.0) (2025-07-01)
 
-#### Features
+### Features
 
 * [feat: "stepwise" assertion format for LLM-friendly output](https://github.com/twada/power-assert-monorepo/pull/23)
 
 
-### 0.1.1
+## 0.1.1
 
   * [chore] upgrade transpiler to v0.4.0
   * [chore] upgrade runtime to v0.2.1
@@ -14,7 +16,7 @@
 ## [0.1.0](https://github.com/twada/power-assert-monorepo/releases/tag/rollup-plugin-power-assert-v0.1.0) (2024-04-25)
 
 
-#### Features
+### Features
 
 * **rollup-plugin-power-assert:**
   * initial release of [Rollup/Vite/Vitest plugin](https://github.com/twada/power-assert-monorepo/pull/7)

--- a/packages/rollup-plugin-power-assert/package.json
+++ b/packages/rollup-plugin-power-assert/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/twada/power-assert-monorepo/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/twada/power-assert-monorepo.git",
+    "url": "git+https://github.com/twada/power-assert-monorepo.git",
     "directory": "packages/rollup-plugin-power-assert"
   },
   "license": "MIT",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,30 +1,32 @@
-### [0.3.1](https://github.com/twada/power-assert-monorepo/releases/tag/runtime-v0.3.1) (2025-10-02)
+# Changelog
 
-#### Bug Fixes
+## [0.3.1](https://github.com/twada/power-assert-monorepo/releases/tag/runtime-v0.3.1) (2025-10-02)
+
+### Bug Fixes
 
 * [fix: filter out Node.js auto-generated assertion messages](https://github.com/twada/power-assert-monorepo/pull/26)
 
 
 ## [0.3.0](https://github.com/twada/power-assert-monorepo/releases/tag/runtime-v0.3.0) (2025-07-01)
 
-#### Features
+### Features
 
 * [feat: "stepwise" assertion format for LLM-friendly output](https://github.com/twada/power-assert-monorepo/pull/23)
 
 
-### 0.2.1
+## 0.2.1
 
-#### Bug Fixes
+### Bug Fixes
 
 * Reduce package size ([eb67efd0](https://github.com/twada/power-assert-monorepo/commit/eb67efd021727e6dd45ef998dce08e5287109923))
 
 
 ## 0.2.0
 
-#### Bug Fixes
+### Bug Fixes
 
 * [Fix regex for prop name quoting](https://github.com/twada/power-assert-monorepo/pull/4)
 
-#### Features
+### Features
 
 * [Symbol as object key](https://github.com/twada/power-assert-monorepo/pull/3)

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/twada/power-assert-monorepo/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/twada/power-assert-monorepo.git",
+    "url": "git+https://github.com/twada/power-assert-monorepo.git",
     "directory": "packages/runtime"
   },
   "license": "MIT",

--- a/packages/swc-plugin-power-assert/CHANGELOG.md
+++ b/packages/swc-plugin-power-assert/CHANGELOG.md
@@ -1,6 +1,8 @@
+# Changelog
+
 ## [0.8.0](https://github.com/twada/power-assert-monorepo/releases/tag/swc-plugin-power-assert-v0.8.0) (2025-07-01)
 
-#### Features
+### Features
 
 * [feat: "stepwise" assertion format for LLM-friendly output](https://github.com/twada/power-assert-monorepo/pull/23)
 
@@ -8,46 +10,46 @@
 ## [0.7.0](https://github.com/twada/power-assert-monorepo/releases/tag/swc-plugin-power-assert-v0.7.0) (2025-06-02)
 
 
-#### Features
+### Features
 
 * **swc-plugin-power-assert:** upgrade swc_core crate to 26.3.* ([eed8cde6](https://github.com/twada/power-assert-monorepo/commit/eed8cde6884621319e334ae07d05b6b00dc85ae6))
 
 
 ## [0.6.0](https://github.com/twada/power-assert-monorepo/releases/tag/swc-plugin-power-assert-v0.6.0) (2025-01-01)
 
-#### Features
+### Features
 
 * [Update swc_core (crate) to v9 to support @swc/core (npm) 1.10.0](https://github.com/twada/power-assert-monorepo/pull/20)
 
 
 ## [0.5.0](https://github.com/twada/power-assert-monorepo/releases/tag/swc-plugin-power-assert-v0.5.0) (2024-08-23)
 
-#### Features
+### Features
 
 * [Update swc_core (crate) to 0.101 to support @swc/core (npm) 1.7.0](https://github.com/twada/power-assert-monorepo/pull/16)
 
 
-### 0.4.2
+## 0.4.2
 
-#### Bug Fixes
+### Bug Fixes
 
 * [Capture CallExpression callee except for Identifier or non-computed MemberExpression](https://github.com/twada/power-assert-monorepo/pull/13)
 
 
-### 0.4.1
+## 0.4.1
 
-#### Bug Fixes
+### Bug Fixes
 
 * update swc_core to 0.95 since v0.94.x is marked as ["Do not use this version if you are building a plugin for SWC"](https://swc.rs/docs/plugin/selecting-swc-core#v094x) ([ffcc200a](https://github.com/twada/power-assert-monorepo/commit/ffcc200a937194e31f789d00cd1c417f6cfcec2e))
 
 
 ## 0.4.0
 
-#### Bug Fixes
+### Bug Fixes
 
 * make code content not optional ([f5a354b0](https://github.com/twada/power-assert-monorepo/commit/f5a354b017f993486c387dcd5bbf3f331f2b1d13))
 
-#### Features
+### Features
 
 * [Adjust CallExpression address if callee is Identifier or non-computed MemberExpression](https://github.com/twada/power-assert-monorepo/pull/12)
 * update swc_core to 0.94 ([f465b768](https://github.com/twada/power-assert-monorepo/commit/f465b7688a58c78a0c8f8318a01938507c291c00))
@@ -55,26 +57,26 @@
 
 ## 0.3.0
 
-#### Bug Fixes
+### Bug Fixes
 
   * skip modifying argument if SpreadElement appears immediately beneath assert ([0d69f3b8](https://github.com/twada/power-assert-monorepo/commit/0d69f3b8373d836ad1f7e98b25e89349b18132a7))
   * [convert absolute path to sandbox path](https://github.com/twada/power-assert-monorepo/pull/10)
 
-#### Features
+### Features
 
   * update swc_core to 0.92 ([057a7ad6](https://github.com/twada/power-assert-monorepo/commit/057a7ad6791b56216641fc0a9bfcc7d98b1a8786))
 
 
 ## [0.2.0](https://github.com/twada/power-assert-monorepo/releases/tag/swc-plugin-power-assert-v0.2.0)
 
-#### Bug Fixes
+### Bug Fixes
 
   * expression address to be embedded should be based on UTF-16 instead of UTF8 ([6f7c47c3](https://github.com/twada/power-assert-monorepo/commit/6f7c47c30780c79e8ff57b44982d89f1f83b4423))
   * store span offset at the beginning of Program/Module node due to SWC issue ([5ef44782](https://github.com/twada/power-assert-monorepo/commit/5ef447829786dd8db3525114fcdd272120b5717f))
   * fix UpdateExpression address when prefix is false ([41f4f491](https://github.com/twada/power-assert-monorepo/commit/41f4f49152ecfc4c9df67123bd3a09de1fa92aa5))
   * do not capture callee of computed MemberExpression ([93185365](https://github.com/twada/power-assert-monorepo/commit/93185365778793d36aaa9ff230f2d113a3c21184))
 
-#### Features
+### Features
 
   * support UnaryExpression ([b741ef9e](https://github.com/twada/power-assert-monorepo/commit/b741ef9e31be01d2af0dfdc5fba3c387f80aaf3b))
   * support NewExpression ([24f28392](https://github.com/twada/power-assert-monorepo/commit/24f2839253c6eb677755a08e6a482fed7dd7d38d))

--- a/packages/swc-plugin-power-assert/Cargo.toml
+++ b/packages/swc-plugin-power-assert/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swc-plugin-power-assert"
-version = "0.8.0"
+version = "0.8.0" # x-release-please-version
 edition = "2021"
 authors = ["Takuto WADA <takuto.wada@gmail.com>"]
 include = ["Cargo.toml", "src/**/*.rs"]

--- a/packages/transpiler-core/CHANGELOG.md
+++ b/packages/transpiler-core/CHANGELOG.md
@@ -1,21 +1,23 @@
+# Changelog
+
 ## [0.5.0](https://github.com/twada/power-assert-monorepo/releases/tag/transpiler-core-v0.5.0) (2025-07-01)
 
-#### Features
+### Features
 
 * [feat: "stepwise" assertion format for LLM-friendly output](https://github.com/twada/power-assert-monorepo/pull/23)
 
 
-### [0.4.2](https://github.com/twada/power-assert-monorepo/releases/tag/transpiler-core-v0.4.2) (2025-06-02)
+## [0.4.2](https://github.com/twada/power-assert-monorepo/releases/tag/transpiler-core-v0.4.2) (2025-06-02)
 
 
-#### Bug Fixes
+### Bug Fixes
 
 * **transpiler-core:** add `attributes` field to ImportDeclaration ([e9b90068](https://github.com/twada/power-assert-monorepo/commit/e9b90068af01af2ab9df47a7819989e8c7565d56))
 
 
-### [0.4.1](https://github.com/twada/power-assert-monorepo/releases/tag/transpiler-core-v0.4.1) (2024-12-31)
+## [0.4.1](https://github.com/twada/power-assert-monorepo/releases/tag/transpiler-core-v0.4.1) (2024-12-31)
 
-#### Chore
+### Chore
 
 * [mark transpiler-core package as "module-sync"](https://github.com/twada/power-assert-monorepo/commit/5ed2a952df)
 * [unsupport string literal import](https://github.com/twada/power-assert-monorepo/pull/18)
@@ -24,7 +26,7 @@
 ## [0.4.0](https://github.com/twada/power-assert-monorepo/releases/tag/transpiler-core-v0.4.0) (2024-06-29)
 
 
-#### Features
+### Features
 
 * [Adjust CallExpression address if callee is Identifier or non-computed MemberExpression](https://github.com/twada/power-assert-monorepo/pull/12)
 
@@ -32,13 +34,13 @@
 ## [0.3.0](https://github.com/twada/power-assert-monorepo/releases/tag/transpiler-core-v0.3.0) (2024-04-17)
 
 
-#### Features
+### Features
 
 * Make `originalCode` argument mandatory ([b4c3b82b](https://github.com/twada/power-assert-monorepo/commit/b4c3b82b3ecb257d0f9b5d4254bf5c4010dd7f87))
 * [Drop CJS support](https://github.com/twada/power-assert-monorepo/pull/6)
 
 
-#### Breaking Changes
+### Breaking Changes
 
 * `options.code` is removed. Move `options.code` to `originalCode` argument. ([b4c3b82b](https://github.com/twada/power-assert-monorepo/commit/b4c3b82b3ecb257d0f9b5d4254bf5c4010dd7f87))
 * New transpiler only supports ESM -> ESM transformation. For CJS support, use [babel-preset-power-assert](https://github.com/power-assert-js/babel-preset-power-assert). ([7b3ad51c](https://github.com/twada/power-assert-monorepo/commit/7b3ad51c74ad267ea31f6ee4b9db8c81bc70d4f2))
@@ -47,11 +49,11 @@
 ## [0.2.0](https://github.com/twada/power-assert-monorepo/releases/tag/transpiler-core-v0.2.0) (2024-03-16)
 
 
-#### Bug Fixes
+### Bug Fixes
 
   * fix UpdateExpression address when prefix is false ([4cb06a8f](https://github.com/twada/power-assert-monorepo/commit/4cb06a8fa9eb902c0a5c4233ac8f61bcaae01a74))
 
-#### Features
+### Features
 
   * [Replace estraverse with estree-walker](https://github.com/twada/power-assert-monorepo/pull/2)
   * support deep capture of UpdateExpression ([2950c026](https://github.com/twada/power-assert-monorepo/commit/2950c02666573cc641a576d4f36995cec5f002c3))

--- a/packages/transpiler-core/package.json
+++ b/packages/transpiler-core/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/twada/power-assert-monorepo/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/twada/power-assert-monorepo.git",
+    "url": "git+https://github.com/twada/power-assert-monorepo.git",
     "directory": "packages/transpiler-core"
   },
   "license": "MIT",

--- a/packages/transpiler/CHANGELOG.md
+++ b/packages/transpiler/CHANGELOG.md
@@ -1,21 +1,23 @@
+# Changelog
+
 ## [0.6.0](https://github.com/twada/power-assert-monorepo/releases/tag/transpiler-v0.6.0) (2025-07-01)
 
-#### Features
+### Features
 
 * [feat: "stepwise" assertion format for LLM-friendly output](https://github.com/twada/power-assert-monorepo/pull/23)
 
 
-### [0.5.2](https://github.com/twada/power-assert-monorepo/releases/tag/transpiler-v0.5.2) (2025-02-12)
+## [0.5.2](https://github.com/twada/power-assert-monorepo/releases/tag/transpiler-v0.5.2) (2025-02-12)
 
 
-#### Bug Fixes
+### Bug Fixes
 
   * set acorn `ecmaVersion` to `2025` to support import attributes again ([f4b3cb3f](https://github.com/twada/power-assert-monorepo/commit/f4b3cb3f7a6d635675ccf119ee7ba94e4c0c21b4))
 
 
-### [0.5.1](https://github.com/twada/power-assert-monorepo/releases/tag/transpiler-v0.5.1) (2024-12-31)
+## [0.5.1](https://github.com/twada/power-assert-monorepo/releases/tag/transpiler-v0.5.1) (2024-12-31)
 
-#### Chore
+### Chore
 
   * [Mark transpiler package as "module-sync"](https://github.com/twada/power-assert-monorepo/commit/269062df6d)
   * [Remove acorn-import-attributes and astring-import-attributes from dependencies since acorn and astring support import attributes by default](https://github.com/twada/power-assert-monorepo/pull/19)
@@ -24,7 +26,7 @@
 
 ## [0.5.0](https://github.com/twada/power-assert-monorepo/releases/tag/transpiler-v0.5.0) (2024-08-23)
 
-#### Features
+### Features
 
   * [Support import attributes](https://github.com/twada/power-assert-monorepo/pull/15)
 
@@ -32,20 +34,20 @@
 ## [0.4.0](https://github.com/twada/power-assert-monorepo/releases/tag/transpiler-v0.4.0) (2024-06-29)
 
 
-#### Features
+### Features
 
   * upgrade transpiler-core to v0.4.0
 
 
 ## [0.3.0](https://github.com/twada/power-assert-monorepo/releases/tag/transpiler-v0.3.0) (2024-04-18)
 
-#### Features
+### Features
 
   * upgrade transpiler-core to v0.3.0
 
 
 ## [0.2.0](https://github.com/twada/power-assert-monorepo/releases/tag/transpiler-v0.2.0)
 
-#### Features
+### Features
 
   * upgrade transpiler-core to v0.2.0

--- a/packages/transpiler/package.json
+++ b/packages/transpiler/package.json
@@ -11,7 +11,7 @@
   "bugs": "https://github.com/twada/power-assert-monorepo/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/twada/power-assert-monorepo.git",
+    "url": "git+https://github.com/twada/power-assert-monorepo.git",
     "directory": "packages/transpiler"
   },
   "license": "MIT",


### PR DESCRIPTION
## Summary

Phase 0 (groundwork) of the release process modernization plan — preparation for release-please + OIDC Trusted Publishing, with no change to the current release flow yet.

- **0-4** Harden `ci.yml`: explicit `permissions: contents: read`, actions pinned to full commit SHAs (checkout v7.0.1 / setup-node v7.0.0 / rust-toolchain 1.95.0), `persist-credentials: false`. npm cache is kept for non-release CI only.
- **0-5** Add `dependabot.yml`: weekly github-actions + npm updates with a 7-day cooldown (avoid freshly published, potentially malicious versions)
- **0-6** Add zizmor workflow security audit (zizmor-action v0.6.2, SHA-pinned)
- **0-7** Unify `repository.url` to the `git+https` form across 5 packages — sigstore provenance verification requires an exact URL match
- **0-9** Normalize all 6 CHANGELOGs for release-please: prepend `# Changelog` H1, version headings at H2, sections at H3. Entry contents and links are unchanged
- **0-10** Mark `esbuild-plugin-power-assert` as `private: true` to structurally prevent accidental publish
- **0-11** Annotate `Cargo.toml` version with `# x-release-please-version` for the release-please generic updater

Repository settings applied out-of-band (not part of this diff):

- **0-3** Workflow permissions: default read-only (was already set) + "Allow GitHub Actions to create and approve pull requests" enabled
- **0-8** Branch ruleset "protect main": require a pull request, block force-pushes and branch deletion, no bypass actors

## Verification

- `npm run lint` — pass
- `npm run build:dist && npm run test:dist` — pass
- local `zizmor .github/workflows/` — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)