### PR TITLE
ci: introduce release-please for automated versioning (Phase 1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+on:
+  push:
+    branches: [ main ]
+
+permissions: {}
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write        # push release PR branch, create GitHub Release/tag
+      pull-requests: write   # create/update/label release PR
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      paths_released: ${{ steps.release.outputs.paths_released }}
+      prs_created: ${{ steps.release.outputs.prs_created }}
+      pr: ${{ steps.release.outputs.pr }}
+    steps:
+      - name: Run release-please
+        id: release
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+
+  # release-please does not update package-lock.json (googleapis/release-please#1993)
+  # nor Cargo.lock, so push a sync commit onto the release PR branch.
+  # Note: this push does not trigger CI on the PR (GITHUB_TOKEN-created events
+  # do not fire workflows), and release.yml itself only triggers on main push,
+  # so no workflow loop occurs.
+  sync-release-pr:
+    needs: release-please
+    if: needs.release-please.outputs.prs_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          # deliberately no dependency caching in the release flow (cache poisoning mitigation)
+      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b # 1.95.0
+        with:
+          targets: wasm32-wasip1
+      - run: npm install --package-lock-only --ignore-scripts
+      - run: cargo update -p swc-plugin-power-assert
+      - name: Commit sync if changed
+        run: |
+          if ! git diff --quiet; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add package-lock.json Cargo.lock
+            git commit -m "chore: sync lockfiles for release"
+            git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,8 @@
+{
+  "packages/transpiler-core": "0.5.0",
+  "packages/transpiler": "0.6.0",
+  "packages/runtime": "0.3.1",
+  "packages/node": "0.6.0",
+  "packages/rollup-plugin-power-assert": "0.2.0",
+  "packages/swc-plugin-power-assert": "0.8.0"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "node",
+  "bump-minor-pre-major": true,
+  "include-component-in-tag": true,
+  "plugins": [
+    { "type": "node-workspace", "updatePeerDependencies": true }
+  ],
+  "packages": {
+    "packages/transpiler-core": { "component": "transpiler-core" },
+    "packages/transpiler": { "component": "transpiler" },
+    "packages/runtime": { "component": "runtime" },
+    "packages/node": { "component": "node" },
+    "packages/rollup-plugin-power-assert": { "component": "rollup-plugin-power-assert" },
+    "packages/swc-plugin-power-assert": {
+      "component": "swc-plugin-power-assert",
+      "extra-files": [
+        { "type": "generic", "path": "Cargo.toml" }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1 of the release process modernization: automated versioning with release-please. **No change to publishing yet** — the workflow only creates/updates release PRs and (after merging one) tags + GitHub Releases. OIDC publish comes in Phase 2.

- **1-1** `release-please-config.json`: manifest mode, `release-type: node`, `bump-minor-pre-major` (all packages are 0.x), `include-component-in-tag` (matches the existing `<component>-vX.Y.Z` tag format), `node-workspace` plugin with `updatePeerDependencies`, and a generic-updater `extra-files` entry for `Cargo.toml` (annotated in Phase 0)
- **1-2** `.release-please-manifest.json`: seeded with the current published versions (npm registry / origin/main / latest tags verified identical on 2026-08-24)
- **1-3** `release.yml` with the release-please job (`contents: write` + `pull-requests: write`, SHA-pinned action v5.0.0)
- **1-4** `sync-release-pr` job: pushes a lockfile sync commit (`npm install --package-lock-only` + `cargo update -p swc-plugin-power-assert`) onto the release PR branch, since release-please updates neither package-lock.json (googleapis/release-please#1993) nor Cargo.lock. Note: the crate name uses hyphens (`swc-plugin-power-assert`)

## What happens after merging

release-please will open the **first release PR** including the unreleased commits already on main. Expected proposal:

| package | version | reason |
|---|---|---|
| @power-assert/node | 0.6.0 → **0.7.0** | feat! (breaking) + bump-minor-pre-major |
| @power-assert/transpiler | 0.6.0 → **0.7.0** | feat ×2 |
| rollup-plugin-power-assert | 0.2.0 → **0.2.1** | cascade: transpiler dependency range rewrite |
| others | unchanged | no releasable commits |

## Verification checklist for the first release PR (Phase 1-5)

- [ ] Proposed versions match the prediction above (a wrong major bump or a `...-v0.0.0`-based compare link means tag matching is broken)
- [ ] Cross-dependency rewrites match the current release.sh behavior (`^0.7.0` in dependents, peerDependencies untouched at `^0.3.1`)
- [ ] CHANGELOG entries are inserted at the top of each file (effect of Phase 0-9 normalization)
- [ ] Lockfile sync commit lands on the PR branch (package-lock.json + Cargo.lock / Cargo.toml version)

**Do not merge the release PR yet** — publishing is still Phase 2. The release PR can stay open (release-please keeps it updated) until Phase 2 is in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)