### PR TITLE
chore: use wildcard ranges for workspace deps in private packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6172,13 +6172,13 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@power-assert/transpiler": "^0.6.0"
+        "@power-assert/transpiler": "*"
       },
       "devDependencies": {
         "esbuild": "^0.28.0"
       },
       "peerDependencies": {
-        "@power-assert/runtime": "^0.3.1"
+        "@power-assert/runtime": "*"
       }
     },
     "packages/integration-tests": {
@@ -6186,12 +6186,12 @@
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@power-assert/node": "^0.6.0",
-        "@power-assert/runtime": "^0.3.1",
-        "@power-assert/transpiler": "^0.6.0",
+        "@power-assert/node": "*",
+        "@power-assert/runtime": "*",
+        "@power-assert/transpiler": "*",
         "@swc/core": "^1.10.0",
         "source-map": "^0.7.4",
-        "swc-plugin-power-assert": "^0.8.0"
+        "swc-plugin-power-assert": "*"
       }
     },
     "packages/node": {

--- a/packages/esbuild-plugin-power-assert/package.json
+++ b/packages/esbuild-plugin-power-assert/package.json
@@ -25,10 +25,10 @@
     "package.json"
   ],
   "dependencies": {
-    "@power-assert/transpiler": "^0.6.0"
+    "@power-assert/transpiler": "*"
   },
   "peerDependencies": {
-    "@power-assert/runtime": "^0.3.1"
+    "@power-assert/runtime": "*"
   },
   "devDependencies": {
     "esbuild": "^0.28.0"

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -5,11 +5,11 @@
   "description": "power-assert integration tests",
   "main": "index.js",
   "devDependencies": {
-    "@power-assert/transpiler": "^0.6.0",
-    "@power-assert/node": "^0.6.0",
-    "@power-assert/runtime": "^0.3.1",
+    "@power-assert/transpiler": "*",
+    "@power-assert/node": "*",
+    "@power-assert/runtime": "*",
     "@swc/core": "^1.10.0",
-    "swc-plugin-power-assert": "^0.8.0",
+    "swc-plugin-power-assert": "*",
     "source-map": "^0.7.4"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

Follow-up to the first release PR (#37) verification. The old release.sh rewrote dependency ranges in **every** package.json (including private packages), but release-please's node-workspace plugin only rewrites ranges between packages listed in the manifest. As a result, on the release PR branch npm resolved `@power-assert/node` 0.6.0 etc. from the **registry** into `packages/integration-tests/node_modules/` instead of linking the workspace — so `test:dist` would run against stale published versions rather than the freshly built ones.

Change the workspace-internal dependency ranges of the two private packages (`@power-assert/integration-tests`, `esbuild-plugin-power-assert`) to `*`:

- `*` always matches the workspace version, so npm always links the workspace and the integration check stays meaningful across bumps
- both packages are private, so range quality for consumers is irrelevant
- external deps (`@swc/core`, `source-map`, `esbuild`) keep their caret ranges

## Verification

- `npm install`: package-lock.json changes are range notation only; all workspace packages remain symlinked, no registry fallback entries
- `npm run lint` / `npm run build:dist` / `npm run test:dist` — pass

After merging, release-please will refresh release PR #37 from the latest main and the stale registry entries in its lockfile sync will disappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)