### PR TITLE
ci: add OIDC publish job with environment gate (Phase 2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,14 @@ name: Release
 on:
   push:
     branches: [ main ]
+  # escape hatch: re-run the publish leg manually when it failed after
+  # release-please has already created the GitHub Releases and tags
+  # (re-running the failed job would reuse the old workflow definition)
+  workflow_dispatch:
+    inputs:
+      paths:
+        description: 'Re-publish target paths as JSON array (e.g. ["packages/runtime"])'
+        required: true
 
 permissions: {}
 
@@ -61,3 +69,40 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ github.token }}
+
+  publish:
+    needs: release-please
+    if: needs.release-please.outputs.releases_created == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment:
+      name: npm              # waits here until the required reviewer approves
+    permissions:
+      contents: read
+      id-token: write        # OIDC token exchange (this job only)
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # default shallow fetch is fine: tests do not depend on git history
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          # deliberately no dependency caching in the release flow (cache poisoning mitigation)
+      - name: Install npm with trusted publishing support
+        # exact-pinned on purpose; review manually when bumping
+        run: npm install -g npm@11.15.0 # zizmor: ignore[adhoc-packages]
+      - uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b # 1.95.0
+        with:
+          targets: wasm32-wasip1
+      - run: npm ci --ignore-scripts
+      - run: npm run build:dist
+      - run: npm run test:dist
+      - name: Publish released packages
+        env:
+          PATHS_RELEASED: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.paths || needs.release-please.outputs.paths_released }}
+        run: |
+          echo "$PATHS_RELEASED" | jq -r '.[]' | while read -r path; do
+            echo "Publishing $path"
+            npm publish --workspace "$path" --provenance --access public
+          done


### PR DESCRIPTION
## Summary

Phase 2-2 of the release process modernization: the tokenless publish leg.

- **publish job**: gated by Environment `npm` (waits for required-reviewer approval), `id-token: write` for OIDC exchange, runs `npm ci --ignore-scripts` + `build:dist` + `test:dist` right before publishing, then loops over `paths_released` with `npm publish --provenance --access public`
- **workflow_dispatch recovery path**: re-running a failed job reuses the old workflow definition, and `paths_released` is empty on dispatch — so re-publish targets are passed explicitly as a JSON-array input (successful packages can be excluded on retry)
- released paths flow through env vars (template-injection mitigation, zizmor-checked)
- npm exact-pinned to 11.15.0 (trusted publishing support); no dependency caching anywhere in the release flow

## Verification

- local `zizmor .github/workflows/` — no findings (1 intentional ignore: `adhoc-packages` for the pinned npm install)
- **`npm ci --ignore-scripts` && `npm run build:dist` && `npm run test:dist` — pass locally** (pre-verifies the 2-4 concern: esbuild and @swc/core have install scripts, but both work via optionalDependencies platform binaries)

## Merge prerequisites (manual, Settings UI / npm CLI)

1. **Environment `npm`** must exist before merging: required reviewer = @twada, "Prevent self-review" disabled, deployment branches = Selected → `main` only, no admin bypass
2. **Trusted Publisher registration** for all 6 packages (`npm trust github`, npm >= 11.15.0, 2FA): repo `twada/power-assert-monorepo`, workflow filename `release.yml` (filename only, no path), environment `npm`

Note: release PR #37 was closed (branch deleted) because release-please does not refresh an existing release PR when base changes leave release notes unchanged. Merging this PR pushes to main, which recreates the release PR from the latest main — with the publish leg already in place for the trial release (node 0.7.0 / transpiler 0.7.0 / rollup-plugin-power-assert 0.2.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)