### PR TITLE
fix: rename dev export condition to package-unique power-assert-dev

### DIFF
--- a/docs/adr-005-node-typescript-type-stripping-migration.md
+++ b/docs/adr-005-node-typescript-type-stripping-migration.md
@@ -4,6 +4,8 @@
 
 Accepted
 
+Amended by [ADR-009](./adr-009-package-unique-dev-condition.md): the `dev` condition described below was later renamed to the package-unique `power-assert-dev`, because the generic name broke downstream consumers running Node.js with their own `--conditions=dev`.
+
 ## Context
 
 The power-assert monorepo has been using a hybrid TypeScript development approach where:

--- a/docs/adr-009-package-unique-dev-condition.md
+++ b/docs/adr-009-package-unique-dev-condition.md
@@ -1,0 +1,54 @@
+# ADR-009: Rename `dev` Export Condition to Package-Unique `power-assert-dev`
+
+## Status
+
+Accepted
+
+Amends [ADR-005](./adr-005-node-typescript-type-stripping-migration.md).
+
+## Context
+
+ADR-005 introduced a `dev` custom condition into the `exports` maps of the published packages, pointing at TypeScript sources (`./src/*.mts`). Running the monorepo's own tests with `node --conditions=dev` resolves inter-package imports to `.mts` sources, which Node.js executes directly via type stripping.
+
+The published tarballs deliberately include the `src/` directory (sourcemap `sources` references), and they also carried the `dev` condition entries in `exports`. This combination breaks downstream consumers in a specific but realistic scenario:
+
+1. A downstream project runs Node.js with `--conditions=dev` for its **own** run-from-source setup. `dev` is a generic, common condition name, so unrelated projects legitimately use it.
+2. Node.js then resolves `@power-assert/*` imports to `.mts` files **inside the consumer's `node_modules`**.
+3. Node.js refuses type stripping under `node_modules` and fails with `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`.
+
+The monorepo itself never observes this failure: npm workspace symlinks realpath to locations outside `node_modules`, so type stripping is permitted.
+
+This was hit in practice on 2026-08-23 by a downstream monorepo whose `test:dev` runner used `--conditions=dev` and had `@power-assert/runtime` 0.3.1 installed.
+
+### Alternatives considered
+
+1. **Strip the `dev` entries from `exports` at publish time** (`prepack` rewriting `package.json`): fixes the tarball completely, but adds fragile publish-time mutation machinery to an otherwise simple release process, and makes the published `package.json` diverge from the repository.
+2. **Exclude `src/` from published `files`**: worse than doing nothing — the `dev` entries would dangle, and resolution under `--conditions=dev` would throw `ERR_MODULE_NOT_FOUND` instead. It would also break sourcemap `sources` references.
+3. **Rename the condition to a package-unique name**: removes the collision with the generic `dev` name at the root. The condition still ships in the tarball, but only an explicit, deliberate `--conditions=power-assert-dev` opts into it.
+
+## Decision
+
+Rename the custom condition from `dev` to **`power-assert-dev`** across the monorepo:
+
+- `exports` maps of `@power-assert/transpiler-core`, `@power-assert/transpiler`, `@power-assert/runtime`, `@power-assert/node`, and `rollup-plugin-power-assert`
+- All npm scripts using `--conditions=dev` (root and per-package)
+- The integration test guard that detects source-mode execution via `process.execArgv`
+
+Custom conditions should be namespaced by project; generic names like `dev` belong to the consumer, not to published packages. This mirrors the convention Node.js documentation suggests for community conditions and matches the same resolution adopted in the sibling mockist monorepo (`mockist-dev`).
+
+## Consequences
+
+### Benefits
+
+1. **Downstream `--conditions=dev` is safe again**: consumers using a generic `dev` condition resolve the compiled `default` entries (`./dist/*.mjs`) as intended.
+2. **No publish-time machinery**: the repository `package.json` and the published one stay identical.
+3. **Sourcemaps keep working**: `src/` remains in the tarballs.
+
+### Trade-offs
+
+1. **The condition still ships**: a consumer who explicitly passes `--conditions=power-assert-dev` will still hit `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`. This is acceptable — the name makes it an explicit opt-in that only makes sense inside this monorepo.
+2. **Slightly more verbose command lines** in development scripts.
+
+### Affected releases
+
+Patch releases of all packages that carried the `dev` condition: `@power-assert/transpiler-core` 0.5.1, `@power-assert/transpiler` 0.7.1, `@power-assert/runtime` 0.3.2, `@power-assert/node` 0.7.1, `rollup-plugin-power-assert` 0.2.2. (`esbuild-plugin-power-assert` and `swc-plugin-power-assert` never carried the condition.)

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "compile": "tsc --build tsconfig.build.json",
     "build:swc": "npm run test -w swc-plugin-power-assert && npm run build -w swc-plugin-power-assert",
     "test:dist": "node --test --test-reporter=dot 'packages/**/dist/**/*_test.mjs'",
-    "test:prove": "prove --exec 'node --conditions=dev --test --test-reporter=tap' -r packages --ext=_test.mts",
-    "test:dev": "node --conditions=dev --test --test-reporter=dot 'packages/**/src/**/__tests__/**/*_test.mts'",
+    "test:prove": "prove --exec 'node --conditions=power-assert-dev --test --test-reporter=tap' -r packages --ext=_test.mts",
+    "test:dev": "node --conditions=power-assert-dev --test --test-reporter=dot 'packages/**/src/**/__tests__/**/*_test.mts'",
     "test": "npm run lint && npm run test:dev"
   },
   "workspaces": [

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -14,10 +14,10 @@
   },
   "scripts": {
     "build:clean": "rimraf dist && rm -f tsconfig.tsbuildinfo",
-    "demo": "node --conditions=dev --no-warnings --enable-source-maps --test --import @power-assert/node 'src/demo/*demo.mts'",
+    "demo": "node --conditions=power-assert-dev --no-warnings --enable-source-maps --test --import @power-assert/node 'src/demo/*demo.mts'",
     "demo:dist": "node --no-warnings --enable-source-maps --test --import @power-assert/node 'dist/demo/*demo.mjs'",
     "test:dist": "node --no-warnings --test --test-reporter=spec 'dist/**/__tests__/**/*test.mjs'",
-    "test": "node --conditions=dev --no-warnings --test --test-reporter=spec 'src/**/__tests__/**/*test.mts'"
+    "test": "node --conditions=power-assert-dev --no-warnings --test --test-reporter=spec 'src/**/__tests__/**/*test.mts'"
   },
   "keywords": [
     "power-assert"

--- a/packages/integration-tests/src/__tests__/integration_test.mts
+++ b/packages/integration-tests/src/__tests__/integration_test.mts
@@ -32,10 +32,10 @@ export function ptest(title: string, testFunc: TestFunc, expected: string, howMa
   const prelude = "import { strict as assert } from 'node:assert';\n";
   const wholeCode = prelude + expression;
 
-  // In this power-assert monorepo, if Node export conditions include 'dev', node test runs typescript code directly by type-stripping feature.
+  // In this power-assert monorepo, if Node export conditions include 'power-assert-dev', node test runs typescript code directly by type-stripping feature.
   // So under that condition, both typescript and rust compiling are skipped, therefore swc-plugin-power-assert will not run at all.
   // In that case, we skip tests for swc-plugin-power-assert.
-  if (!process.execArgv.includes('--conditions=dev')) {
+  if (!process.execArgv.includes('--conditions=power-assert-dev')) {
     test('swc-plugin-power-assert - ' + title + ': ' + expression, async () => {
       // write to file since swc-plugin-power-assert requires target file existence in appropriate path
       writeFileSync(inputFilepath, wholeCode);

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -24,24 +24,24 @@
     ".": {
       "module-sync": {
         "types": "./dist/register.d.mts",
-        "dev": "./src/register.mts",
+        "power-assert-dev": "./src/register.mts",
         "default": "./dist/register.mjs"
       },
       "import": {
         "types": "./dist/register.d.mts",
-        "dev": "./src/register.mts",
+        "power-assert-dev": "./src/register.mts",
         "default": "./dist/register.mjs"
       }
     },
     "./hooks": {
       "module-sync": {
         "types": "./dist/hooks.d.mts",
-        "dev": "./src/hooks.mts",
+        "power-assert-dev": "./src/hooks.mts",
         "default": "./dist/hooks.mjs"
       },
       "import": {
         "types": "./dist/hooks.d.mts",
-        "dev": "./src/hooks.mts",
+        "power-assert-dev": "./src/hooks.mts",
         "default": "./dist/hooks.mjs"
       }
     },
@@ -74,11 +74,11 @@
   },
   "scripts": {
     "build:clean": "rimraf dist && rm -f tsconfig.tsbuildinfo",
-    "example:ts": "node --conditions=dev --experimental-strip-types --enable-source-maps --import @power-assert/node --test examples/bowling.test.mts",
-    "example": "node --conditions=dev --enable-source-maps --import @power-assert/node --test examples/bowling.test.mjs",
-    "demo": "node --conditions=dev --enable-source-maps --import @power-assert/node --test examples/demo.test.mjs",
-    "test:js": "node --conditions=dev --enable-source-maps --import @power-assert/node --test examples/bowling.test.mjs | grep 'examples/bowling.test.mjs:110:7'",
-    "test:ts": "node --conditions=dev --experimental-strip-types --enable-source-maps --import @power-assert/node --test examples/bowling.test.mts | grep 'examples/bowling.test.mts:114:7'",
+    "example:ts": "node --conditions=power-assert-dev --experimental-strip-types --enable-source-maps --import @power-assert/node --test examples/bowling.test.mts",
+    "example": "node --conditions=power-assert-dev --enable-source-maps --import @power-assert/node --test examples/bowling.test.mjs",
+    "demo": "node --conditions=power-assert-dev --enable-source-maps --import @power-assert/node --test examples/demo.test.mjs",
+    "test:js": "node --conditions=power-assert-dev --enable-source-maps --import @power-assert/node --test examples/bowling.test.mjs | grep 'examples/bowling.test.mjs:110:7'",
+    "test:ts": "node --conditions=power-assert-dev --experimental-strip-types --enable-source-maps --import @power-assert/node --test examples/bowling.test.mts | grep 'examples/bowling.test.mts:114:7'",
     "test": "npm run test:js && npm run test:ts"
   }
 }

--- a/packages/rollup-plugin-power-assert/package.json
+++ b/packages/rollup-plugin-power-assert/package.json
@@ -30,12 +30,12 @@
     ".": {
       "module-sync": {
         "types": "./dist/rollup-plugin-power-assert.d.mts",
-        "dev": "./src/rollup-plugin-power-assert.mts",
+        "power-assert-dev": "./src/rollup-plugin-power-assert.mts",
         "default": "./dist/rollup-plugin-power-assert.mjs"
       },
       "import": {
         "types": "./dist/rollup-plugin-power-assert.d.mts",
-        "dev": "./src/rollup-plugin-power-assert.mts",
+        "power-assert-dev": "./src/rollup-plugin-power-assert.mts",
         "default": "./dist/rollup-plugin-power-assert.mjs"
       }
     },
@@ -65,6 +65,6 @@
     "example": "rollup --config rollup.config.power.mjs && node --test --enable-source-maps tmp/bowling.test.js",
     "vitest": "vitest run",
     "build:clean": "rimraf dist && rm -f tsconfig.tsbuildinfo && rimraf tmp",
-    "test": "node --conditions=dev --test 'src/**/__tests__/**/*test.mts'"
+    "test": "node --conditions=power-assert-dev --test 'src/**/__tests__/**/*test.mts'"
   }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -29,12 +29,12 @@
     ".": {
       "module-sync": {
         "types": "./dist/runtime.d.mts",
-        "dev": "./src/runtime.mts",
+        "power-assert-dev": "./src/runtime.mts",
         "default": "./dist/runtime.mjs"
       },
       "import": {
         "types": "./dist/runtime.d.mts",
-        "dev": "./src/runtime.mts",
+        "power-assert-dev": "./src/runtime.mts",
         "default": "./dist/runtime.mjs"
       }
     },
@@ -49,6 +49,6 @@
   ],
   "scripts": {
     "build:clean": "rimraf dist && rm -f tsconfig.tsbuildinfo",
-    "test": "node --conditions=dev --test 'src/**/__tests__/**/*test.mts'"
+    "test": "node --conditions=power-assert-dev --test 'src/**/__tests__/**/*test.mts'"
   }
 }

--- a/packages/transpiler-core/package.json
+++ b/packages/transpiler-core/package.json
@@ -29,12 +29,12 @@
     ".": {
       "module-sync": {
         "types": "./dist/transpiler-core.d.mts",
-        "dev": "./src/transpiler-core.mts",
+        "power-assert-dev": "./src/transpiler-core.mts",
         "default": "./dist/transpiler-core.mjs"
       },
       "import": {
         "types": "./dist/transpiler-core.d.mts",
-        "dev": "./src/transpiler-core.mts",
+        "power-assert-dev": "./src/transpiler-core.mts",
         "default": "./dist/transpiler-core.mjs"
       }
     },
@@ -58,6 +58,6 @@
   },
   "scripts": {
     "build:clean": "rimraf dist && rm -f tsconfig.tsbuildinfo",
-    "test": "node --conditions=dev --test 'src/**/__tests__/**/*test.mts'"
+    "test": "node --conditions=power-assert-dev --test 'src/**/__tests__/**/*test.mts'"
   }
 }

--- a/packages/transpiler/package.json
+++ b/packages/transpiler/package.json
@@ -24,12 +24,12 @@
     ".": {
       "module-sync": {
         "types": "./dist/transpile-with-sourcemap.d.mts",
-        "dev": "./src/transpile-with-sourcemap.mts",
+        "power-assert-dev": "./src/transpile-with-sourcemap.mts",
         "default": "./dist/transpile-with-sourcemap.mjs"
       },
       "import": {
         "types": "./dist/transpile-with-sourcemap.d.mts",
-        "dev": "./src/transpile-with-sourcemap.mts",
+        "power-assert-dev": "./src/transpile-with-sourcemap.mts",
         "default": "./dist/transpile-with-sourcemap.mjs"
       }
     },


### PR DESCRIPTION
## Summary

The published tarballs carry a generic `dev` condition in their `exports` maps pointing at TypeScript sources under `src/`. A downstream project running Node.js with its own `--conditions=dev` (a common generic condition for run-from-source setups) resolves `@power-assert/*` imports to `.mts` files inside its `node_modules`, where Node.js refuses type stripping and fails with `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`. This was hit in practice by a downstream monorepo on 2026-08-23.

Rename the condition to the package-unique **`power-assert-dev`** across the monorepo (exports maps, npm scripts, the integration-test source-mode guard). Consumers with `--conditions=dev` now resolve the compiled `default` entries; the monorepo keeps running tests from TypeScript sources via `--conditions=power-assert-dev`. Design record: ADR-009 (amends ADR-005).

This branch predates the release-process modernization and was recreated from the current main as decided in ADR-010 planning (D6): the original hand-written CHANGELOG commit and five version-bump commits were dropped — versioning and CHANGELOGs are release-please's job now. The ADR's "Affected releases" section was updated to the post-0.7.0 version numbers.

## Expected release (for the release PR review)

One `fix:` commit touching 5 released packages → release-please should propose patch bumps for all of them: transpiler-core **0.5.1**, transpiler **0.7.1**, runtime **0.3.2**, node **0.7.1**, rollup-plugin-power-assert **0.2.2**. swc-plugin is untouched (Cargo sync should be a no-op).

## Verification

- `npm run lint` / `npm run test:dev` / `npm run build:dist` / `npm run test:dist` — all pass. `test:dev` runs under `--conditions=power-assert-dev`, exercising the rename itself
- Sweep for leftovers: no `--conditions=dev` and no generic `"dev"` exports condition remain (only `"dev": true` devDependency markers in package-lock.json)
- `npm install` produces no lockfile change (exports/condition changes do not affect resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)