### PR TITLE
docs: add duplicate-changelog-entry check to release PR review steps

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -58,6 +58,14 @@ Released packages: `@power-assert/transpiler-core`, `@power-assert/transpiler`,
    links (a wrong major bump or a `v0.0.0`-based compare link means tag
    matching is broken), and always review the diff of `.github/workflows` and
    lockfiles before approving anything.
+   Also check the CHANGELOGs for **duplicate entries**: when a merged PR's
+   title is in Conventional Commits form, GitHub's merge commit carries that
+   title in its body, and release-please may extract it as an extra entry
+   alongside the PR's actual commits (observed with PR #42, where the merge
+   commit produced a second `fix:` entry; the trigger conditions are not fully
+   understood, so check every release). Remove the duplicate — the entry
+   linking the merge commit — by hand-editing the release PR per the
+   CHANGELOG policy above.
 2. **Approve the `npm` environment deployment**
    (Actions → the waiting Release run → Review deployments → `npm`).
 3. The publish job runs `npm ci --ignore-scripts`, `npm run build:dist`,


### PR DESCRIPTION
## Summary

Follow-up to the 0.7.1/0.5.1/0.3.2/0.2.2/0.8.1 release. During the release PR (#43) review, each affected CHANGELOG contained the same fix entry twice: once linking the actual commit (5bf0642) and once linking the merge commit of PR #42 (c880922). GitHub's merge commits carry the PR title in their body, and since that title was in Conventional Commits form, release-please extracted it as an additional entry.

Notably, PR #28 had the same structure (conventional title, plain merge) and did **not** produce duplicates in the 0.7.0 release, so the trigger conditions are not fully understood. Rather than relying on title conventions to avoid it, add the duplicate check to the release PR review steps in RELEASING.md so it is caught every time; the fix is the already-documented hand-edit procedure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)