### PR TITLE
chore: add pr-authoring skill encoding the squash-merge PR workflow

### DIFF
--- a/.claude/skills/pr-authoring/SKILL.md
+++ b/.claude/skills/pr-authoring/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: pr-authoring
+description: Author pull requests for this repository under its squash-merge + release-please regime — Conventional Commits PR titles that drive releases, and PR bodies written to commit-message quality because the squash merge turns the PR body into the permanent git commit body. Use whenever creating a PR, drafting or revising a PR title or body or description, preparing to squash-merge, or shipping committed work as a PR — whether the request is in English or Japanese, and even if the user only says "create a PR", "open a pull request", "send/raise a PR", "push and make a PR", "fix the PR wording", "PR にして", "push して PR 作成", or "PR の文面を直して".
+---
+
+# PR Authoring
+
+## Why this workflow exists
+
+This repository squash-merges PRs with the presets PR_TITLE + PR_BODY:
+the PR title becomes the commit subject (with ` (#N)` appended) and the
+PR description becomes the commit body, verbatim (GitHub hard-wraps it at
+about 72 columns at merge time). Two consequences drive everything below:
+
+1. **The PR body is permanent git history.** It must satisfy
+   commit-message quality, and must make sense to a `git log` reader who
+   has no access to GitHub — the repository treats git, not GitHub, as
+   the durable record of intent.
+2. **release-please parses the squash commit.** The title's type decides
+   whether a release happens; stray Conventional-Commits-shaped text in
+   the body can create changelog entries on its own.
+
+Full rationale and the research behind these rules:
+[docs/investigations/2026-08-27-release-please-changelog-duplication-research.en.md](../../../docs/investigations/2026-08-27-release-please-changelog-duplication-research.en.md)
+
+## PR title
+
+- Conventional Commits form: `type(scope): summary` — lowercase summary,
+  imperative mood, English.
+- The type drives release-please, so choose it deliberately (see also
+  CLAUDE.md's release rules): `fix:` / `feat:` on package code produce a
+  release PR; `chore:` / `ci:` / `docs:` / `refactor:` / `test:` are
+  hidden from the changelog and never release.
+- A breaking change is marked with `!` (`feat(runtime)!: …`). The title
+  cannot carry details — those go in the body as a footer paragraph
+  (next section).
+- Keep the title comfortably short: GitHub appends ` (#N)` and the whole
+  line is the commit subject.
+
+## PR body — the durable-information filter
+
+Write the body as the commit message it will become. For every line ask:
+*does this help someone reading `git log` years from now, possibly
+without GitHub?*
+
+- Structured markdown headers are welcome — `## Summary` / `## Motivation`
+  / `## Changes` / `## Testing` / `## References`, or `## What / Why`
+  style. Markdown reads fine as plain text, so structure costs nothing.
+- Belongs in the body: the intent and motivation, what changed and why
+  this approach, which tests were added **and that they fail without the
+  change**, and issue references (`Fixes #N` — closes the issue and the
+  reference survives in git).
+- Does NOT belong in the body — post as the PR's **first comment**
+  instead: review checklists, screenshots, reviewer verification steps
+  ("run X and observe Y"), open questions for the reviewer. These are
+  review-time information; fossilized in a commit body they are noise.
+- Put long paths and URLs on their own line, never inside a bullet with
+  other text: the 72-column wrap at merge time mangles long bullets.
+
+## Breaking changes
+
+The `!` in the title only marks the semver bump. The detailed CHANGELOG
+entry comes from a bare footer paragraph in the body:
+
+```
+BREAKING CHANGE: <user-visible impact, and how to migrate>
+```
+
+Write it as its own paragraph starting at column 0. Omitting it means
+the changelog's breaking-changes section shows only the title — how a
+breaking change gets under-documented (this failure mode and its costly
+manual recovery are documented in the investigation report).
+
+## release-please pitfalls — preflight every body
+
+Before `gh pr create`, and again after any body edit, run:
+
+```bash
+.claude/skills/pr-authoring/scripts/check-pr-body.sh <body-file> [<title>]
+```
+
+It rejects the two known hazards:
+
+1. **A paragraph starting with a bare Conventional Commits line**
+   (`fix: …` at column 0 after a blank line). release-please deliberately
+   splits commit bodies on such paragraphs, each becoming an extra
+   changelog entry. When quoting commit-like text in prose, keep it from
+   starting a paragraph — backticks, a list bullet, or reflowing the
+   sentence all prevent the match. Exception: a PR intentionally carrying
+   several releasable units may use bare paragraphs for exactly this
+   effect — prefer splitting the PR, and pass `--allow-cc-paragraphs`
+   only when the extra entries are wanted.
+2. **The literal commit-override marker strings.** release-please scans
+   merged PR bodies for them with a plain substring match; a prose
+   mention hijacks commit parsing silently (discovered first-hand in this
+   repository — see the investigation report). Refer to them obliquely,
+   e.g. "the commit-override markers".
+
+Given the title, the script also cross-checks breaking-change
+consistency (`!` in the title vs. a `BREAKING CHANGE:` paragraph in the
+body) and warns on either being present without the other.
+
+## Merging
+
+Squash merge is the default. In the merge dialog, confirm the subject is
+the PR title and the body is the PR description (the presets prefill
+this; a stray edit can reintroduce noise). Plain merges remain possible
+during the transition period, but they reintroduce the
+duplicate-changelog-entry problem documented in RELEASING.md — a
+Conventional-Commits-form PR title lands in the merge commit body and is
+counted twice.

--- a/.claude/skills/pr-authoring/scripts/check-pr-body.sh
+++ b/.claude/skills/pr-authoring/scripts/check-pr-body.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Preflight check for PR bodies in this repository's squash-merge +
+# release-please regime. The PR body becomes the squash commit body
+# verbatim, and release-please parses it; this script catches the text
+# shapes that trigger unintended release-please behavior.
+#
+# Usage: check-pr-body.sh [--allow-cc-paragraphs] <body-file> [<pr-title>]
+# Exit status: 0 = clean (warnings allowed), 1 = hazard found or usage error.
+set -u
+
+allow_cc=0
+if [ "${1:-}" = "--allow-cc-paragraphs" ]; then
+  allow_cc=1
+  shift
+fi
+
+body_file="${1:-}"
+title="${2:-}"
+
+if [ -z "$body_file" ] || [ ! -f "$body_file" ]; then
+  echo "usage: check-pr-body.sh [--allow-cc-paragraphs] <body-file> [<pr-title>]" >&2
+  exit 1
+fi
+
+status=0
+
+# 1. Paragraphs starting with a bare Conventional Commits line.
+#    release-please's splitMessages() splits the commit body on
+#    /\n\n(?=(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.*?\))?: )/
+#    and each match becomes an extra changelog entry. The type list and
+#    the paragraph-start anchoring below mirror that regex exactly.
+cc_hits=$(awk '
+  prev_blank && $0 ~ /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^)]*\))?!?: / {
+    print NR": "$0
+  }
+  { prev_blank = ($0 == "") }
+  BEGIN { prev_blank = 1 }
+' "$body_file")
+if [ -n "$cc_hits" ]; then
+  if [ "$allow_cc" -eq 1 ]; then
+    echo "NOTE: bare Conventional Commits paragraph(s) allowed by flag (each becomes a changelog entry):"
+    echo "$cc_hits"
+  else
+    echo "HAZARD: paragraph(s) start with a bare Conventional Commits line — release-please will emit each as an extra changelog entry:"
+    echo "$cc_hits"
+    echo "Reword so the paragraph does not start with the type (backticks, a bullet, or reflowing all work), split the PR, or pass --allow-cc-paragraphs if the extra entries are intended."
+    status=1
+  fi
+fi
+
+# 2. Literal commit-override marker strings. release-please matches them
+#    as plain substrings anywhere in the merged PR body; a mention in
+#    prose silently replaces the commit message it parses.
+for marker in "BEGIN_COMMIT_OVERRIDE" "END_COMMIT_OVERRIDE"; do
+  if grep -qF "$marker" "$body_file"; then
+    echo "HAZARD: literal override marker '$marker' found — release-please matches it as a bare substring and hijacks commit parsing. Refer to it obliquely (e.g. \"the commit-override markers\")."
+    status=1
+  fi
+done
+
+# 3. Breaking-change consistency between title and body (warnings only).
+if [ -n "$title" ]; then
+  title_breaking=0
+  case "$title" in
+    *!:*) title_breaking=1 ;;
+  esac
+  body_breaking=0
+  if grep -qE '^BREAKING[ -]CHANGE: ' "$body_file"; then
+    body_breaking=1
+  fi
+  if [ "$title_breaking" -eq 1 ] && [ "$body_breaking" -eq 0 ]; then
+    echo "WARNING: title marks a breaking change (!) but the body has no 'BREAKING CHANGE:' paragraph — the changelog's breaking section will show only the title."
+  fi
+  if [ "$title_breaking" -eq 0 ] && [ "$body_breaking" -eq 1 ]; then
+    echo "WARNING: body has a 'BREAKING CHANGE:' paragraph but the title has no '!' — add the marker so the semver bump matches the documented break."
+  fi
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "OK: no release-please hazards found in $body_file"
+fi
+exit "$status"


### PR DESCRIPTION
## Summary

Add a project skill, `.claude/skills/pr-authoring/`, that encodes this repository's PR-authoring conventions for the squash-merge + release-please regime, plus a preflight script that mechanically checks a PR body for the known release-please hazards before the PR is created.

## Motivation

The conventions were established across RELEASING.md, ADR-010, and the investigation report, but documentation only helps when a session happens to read it. A skill turns the conventions into a workflow that triggers whenever a PR is being authored, and the preflight script replaces "should be safe" reasoning with a deterministic check. The rules encoded: Conventional Commits titles whose type deliberately drives (or avoids) a release; PR bodies written to commit-message quality because the squash merge makes them the permanent git commit body; review-only material separated into the PR's first comment; breaking changes carried by a bare footer paragraph so the changelog shows more than the title.

## Changes

- `SKILL.md` — the workflow: title rules, the durable-information filter for bodies, breaking-change handling, preflight, and merge guidance, with the why behind each rule and a pointer to the investigation report for the full rationale. Trigger phrases cover both English and Japanese requests.
- `scripts/check-pr-body.sh` — rejects paragraphs starting with a bare Conventional Commits line (mirroring release-please's body-splitting regex exactly) and any literal commit-override marker, and warns when the title's breaking marker and the body's breaking footer disagree. Supports `--allow-cc-paragraphs` for the rare intentional multi-unit PR.

## Testing

- The script was self-tested against five fixture bodies covering clean text, a bare Conventional Commits paragraph, a marker mention in prose, a hazard on the very first line, and the allow-flag path.
- The skill was evaluated with three realistic drafting tasks (a breaking API removal, a docs change with reviewer-only verification steps, and a pitfall-tempting task about documenting the override markers themselves), each run with and without the skill. All 13 assertions passed with the skill; the with-skill runs uniquely executed the preflight and showed markedly lower time variance.

## References

Full rationale and research:

docs/investigations/2026-08-27-release-please-changelog-duplication-research.en.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)