### PR TITLE
docs: add ADR-011 recording the squash-merge transition decision

### DIFF
--- a/docs/adr-010-release-process-modernization.md
+++ b/docs/adr-010-release-process-modernization.md
@@ -9,6 +9,11 @@ Accepted (implemented 2026-08-24/25; first release through the new pipeline:
 rewrite, `Cargo.lock` sync, `prepack` cargo build — and the peer-dependency
 cascade)
 
+Amended by [ADR-011](./adr-011-squash-merge-pr-body-as-commit-body.md)
+(2026-08-27): the plain-merge strategy assumed below, and its
+duplicate-changelog-entry trade-off, are superseded by a gradual
+transition to squash merge with the PR body as the commit body.
+
 ## Context
 
 The npm supply-chain threat model has shifted from "malicious package code" to
@@ -135,7 +140,10 @@ is [RELEASING.md](../RELEASING.md).
   Mitigated by a duplicate-entry check in the release PR review steps plus
   the hand-edit procedure (both in RELEASING.md). Full analysis and a survey
   of how the ecosystem avoids the problem (squash-merge + PR-title linting):
-  [investigations/2026-08-27-release-please-changelog-duplication-research.en.md](./investigations/2026-08-27-release-please-changelog-duplication-research.en.md)
+  [investigations/2026-08-27-release-please-changelog-duplication-research.en.md](./investigations/2026-08-27-release-please-changelog-duplication-research.en.md).
+  Superseded for squash-merged PRs by
+  [ADR-011](./adr-011-squash-merge-pr-body-as-commit-body.md) — the check
+  now applies only to plain merges made during the transition
 - `updatePeerDependencies` rewrites peer ranges even when the released
   version already satisfies them, pulling the dependent package into the
   release with a patch bump despite having no code changes (e.g.

--- a/docs/adr-011-squash-merge-pr-body-as-commit-body.md
+++ b/docs/adr-011-squash-merge-pr-body-as-commit-body.md
@@ -1,0 +1,91 @@
+# ADR-011: Squash Merge with the PR Body as the Commit Body
+
+## Status
+
+Accepted (2026-08-27; presets applied the same day, first squash merges:
+PRs #47, #48, #49)
+
+Amends [ADR-010](./adr-010-release-process-modernization.md).
+
+## Context
+
+ADR-010 built the release automation on plain merge commits and accepted a
+trade-off: when a merged PR's title is in Conventional Commits form,
+release-please emits a duplicate changelog entry, to be removed by
+hand-editing the release PR.
+
+Research on 2026-08-27 made that trade-off's cause deterministic:
+release-please deliberately splits commit message bodies on
+paragraph-leading Conventional Commits lines, GitHub's plain merge commits
+carry the PR title in their body, and upstream closed the report as not
+planned. As long as PR titles follow Conventional Commits — this
+repository's convention — plain merges duplicate entries structurally, not
+accidentally. The full mechanism, the ecosystem survey (squash merge with
+Conventional-Commits PR titles is the dominant practice; npm's
+title-plus-description squash configuration is proven with release-please,
+breaking-change footers included), and the pitfalls are recorded in
+[the investigation report](./investigations/2026-08-27-release-please-changelog-duplication-research.en.md).
+
+A second concern shaped which squash configuration to adopt: durability of
+intent outside GitHub. This repository treats git itself, not GitHub, as
+the durable record — detailed rationale must survive in `git log` even if
+the project ever leaves the platform. A squash configuration that keeps
+only the PR title would move the narrative of every change into a
+proprietary silo.
+
+## Decision
+
+1. **Transition gradually from plain merges to squash merges.** The
+   atomic, revertable unit of history is the squashed PR. PRs are expected
+   to shrink toward single-intent changes, with behavior changes and
+   structure changes separated at the PR level (in the tidy-first sense);
+   a PR carrying multiple releasable units should become rare.
+2. **Squash message presets are pinned to subject = PR title, body = PR
+   description** (GitHub's "Pull request title and description"). The PR
+   description thereby becomes the permanent commit body.
+3. **The PR description is the canonical narrative of a change**, written
+   to commit-message quality. Review-only material (checklists,
+   screenshots, reviewer verification steps) goes into the PR's first
+   comment instead, so it never fossilizes in git history.
+4. **Enforcement is delegated to the project skill**
+   `.claude/skills/pr-authoring/` (workflow rules plus a preflight script
+   that mechanically rejects the known release-please hazards). This ADR
+   records the decision; the skill records the evolving procedure; the
+   investigation report records the evidence.
+
+## Alternatives considered
+
+- **Keep plain merges** (the ADR-010 status quo). Preserves branch
+  commits and their footers verbatim, but the duplicate-entry hand-edit
+  becomes a permanent tax, and the collision between
+  Conventional-Commits PR titles and release-please never ends.
+- **Squash with a title-only message** (blank body). Solves the
+  duplication, but the detailed rationale of every change would live only
+  in the PR — leaving GitHub would lose it. Rejected on durability
+  grounds.
+- **Rebase merge.** Keeps each commit verbatim and no merge commit ever
+  carries the title, but PR boundaries and numbers vanish from history,
+  losing the grouping of commits into one logical change.
+
+## Consequences
+
+- Duplicate changelog entries are structurally impossible for
+  squash-merged PRs. RELEASING.md's duplicate-entry check remains
+  relevant only for plain merges made during the transition; once squash
+  is the norm, RELEASING.md and the amended parts of ADR-010 should be
+  revised.
+- `BREAKING CHANGE:` details reach the changelog through a bare footer
+  paragraph in the PR description. A missing footer silently degrades the
+  changelog's breaking section to the bare title — the costly failure
+  mode npm/cli documented — so the skill's preflight cross-checks the
+  title's `!` against the body's footer.
+- Two release-please hazards become standing operating rules, enforced by
+  the preflight script: no unintentional paragraph-leading Conventional
+  Commits lines in a PR description, and never spelling the literal
+  commit-override marker strings in a PR body.
+- The commit-override mechanism, unusable under plain merges, becomes the
+  retroactive fix for release notes on squash-merged PRs.
+- Branch commits' individual messages die at squash. The finest durable
+  grain of the development narrative is the PR; branch commits are
+  working checkpoints, and exploration history lives in session
+  transcripts, not in `git log`.


### PR DESCRIPTION
## Summary

Record the 2026-08-27 merge-strategy decision as ADR-011 and mark ADR-010 as amended by it.

## Motivation

The decision to transition from plain merges to squash merges with the PR body as the commit body was made and applied during the 2026-08-27 working session, but it lived scattered across an investigation report's implications section, a squash commit, and a skill. It partially reverses a trade-off ADR-010 explicitly accepted (the duplicate-changelog-entry hand-edit under plain merges), so without an ADR, ADR-010 misrepresents the current regime. This ADR fixes the decision in the repository's established decision-record genre: the ADR records what was chosen over which alternatives and why; the investigation report keeps the evidence; the pr-authoring skill keeps the evolving procedure.

## Changes

- New ADR-011 "Squash Merge with the PR Body as the Commit Body": context (the deterministic duplication mechanism, the durability-of-intent concern), the four-part decision (gradual squash transition with the squashed PR as the atomic unit of history, pinned title/description presets, the PR description as canonical narrative with review-only material separated, enforcement delegated to the skill), alternatives considered (keep plain merges, title-only squash, rebase merge), and consequences including the standing operating rules and what dies at squash.
- ADR-010: an "Amended by ADR-011" note in the Status section, and a superseded note at the duplicate-entry trade-off bullet, which now applies only to plain merges made during the transition.

## References

New file:

docs/adr-011-squash-merge-pr-body-as-commit-body.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)