### PR TITLE
chore: add build-free type check and fast static check batch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         # npm cache is acceptable here (non-release CI); release workflow must not use caching
         cache: 'npm'
     - run: npm ci
-    - run: npm run lint
+    - run: npm run check
     - run: npm run test:dev
 
     - name: Setup Rust

--- a/docs/adr-005-node-typescript-type-stripping-migration.md
+++ b/docs/adr-005-node-typescript-type-stripping-migration.md
@@ -6,6 +6,8 @@ Accepted
 
 Amended by [ADR-009](./adr-009-package-unique-dev-condition.md): the `dev` condition described below was later renamed to the package-unique `power-assert-dev`, because the generic name broke downstream consumers running Node.js with their own `--conditions=dev`.
 
+See also [ADR-012](./adr-012-build-free-typecheck-via-custom-conditions.md): the deferral of type checking to `build:dist` that this migration introduced was later closed by a build-free whole-repository type check resolving workspace imports through the same condition.
+
 ## Context
 
 The power-assert monorepo has been using a hybrid TypeScript development approach where:

--- a/docs/adr-009-package-unique-dev-condition.md
+++ b/docs/adr-009-package-unique-dev-condition.md
@@ -6,6 +6,8 @@ Accepted
 
 Amends [ADR-005](./adr-005-node-typescript-type-stripping-migration.md).
 
+Amended by [ADR-012](./adr-012-build-free-typecheck-via-custom-conditions.md): the `power-assert-dev` condition later gained a second role — resolving workspace imports to sources for build-free type checking — which makes its position ahead of `"types"` in each `exports` map load-bearing.
+
 ## Context
 
 ADR-005 introduced a `dev` custom condition into the `exports` maps of the published packages, pointing at TypeScript sources (`./src/*.mts`). Running the monorepo's own tests with `node --conditions=dev` resolves inter-package imports to `.mts` sources, which Node.js executes directly via type stripping.

--- a/docs/adr-012-build-free-typecheck-via-custom-conditions.md
+++ b/docs/adr-012-build-free-typecheck-via-custom-conditions.md
@@ -1,0 +1,37 @@
+# ADR-012: Build-Free Type Checking via the `power-assert-dev` Custom Condition
+
+## Status
+
+Accepted
+
+Amends [ADR-009](./adr-009-package-unique-dev-condition.md) (gives the `power-assert-dev` condition a second role). Addresses a consequence of [ADR-005](./adr-005-node-typescript-type-stripping-migration.md).
+
+## Context
+
+ADR-005 moved the development test loop onto Node.js type stripping: `npm run test:dev` executes `.mts` sources directly, so tests run fast and frequently without a build step. The trade-off was that type checking silently moved to the back of the pipeline — the only `tsc` invocation left was the emitting `tsc --build` inside `build:dist`, so type errors surfaced at release-preparation time rather than during everyday development.
+
+Meanwhile the toolchain had been progressively replaced with fast tools — oxlint ([ADR-008](./adr-008-eslint-to-oxc-migration.md)), oxfmt, and the native TypeScript 7 compiler (adopted 2026-08-29, cutting the full project-references build from ~5.2s to ~0.95s). A whole-repository static check became cheap enough to run on every edit, so the goal was set: lint, format check, type check, and tests should all run in one fast batch (`npm run check` / `npm test`), with type checking no longer deferred.
+
+The obstacle is monorepo-specific. A check-only `tsc -p tsconfig.typecheck.json` over all workspace sources must resolve cross-package imports such as `@power-assert/transpiler-core`. Those resolve through each package's `exports` map, whose `"types"` condition points at built typings (`./dist/*.d.mts`) — requiring exactly the build the type check is trying to avoid, or worse, binding against stale typings from an earlier build.
+
+The `exports` maps already contain a `power-assert-dev` condition (introduced by ADR-005, renamed by ADR-009) pointing at the `./src/*.mts` sources, used by Node.js at development runtime via `--conditions=power-assert-dev`.
+
+### Alternatives considered
+
+1. **`paths` mapping in `tsconfig.typecheck.json`**: map each workspace package name to its entry source file. Works deterministically, but duplicates the entry-point list already encoded in the `exports` maps, must be maintained by hand as packages and subpaths (e.g. `@power-assert/node/hooks`) are added, and expresses "resolve to source" in a second, tsconfig-specific mechanism.
+2. **`customConditions: ["power-assert-dev"]` with `exports` maps unchanged**: appears to work on a clean tree, but only by accident — TypeScript matches the `"types"` condition first (key order wins), finds `./dist/*.d.mts` missing, and falls through to `power-assert-dev`. As soon as `dist` exists, `"types"` wins and the check binds to stale built typings. A mutation experiment (changing an exported function's parameter type without rebuilding) confirmed the failure mode: errors inside the edited package were still reported, but all call-site errors in dependent packages were silently missed. The check's coverage would depend nondeterministically on the presence and freshness of `dist` — reintroducing the deferred-typecheck problem in a harder-to-notice form.
+3. **`tsc --build` over the project references**: requires emitting declarations, which is the very coupling of type checking to building that this decision removes.
+
+## Decision
+
+1. Add `tsconfig.typecheck.json`: a single non-composite, `noEmit`, incremental program including `packages/*/src/**/*.mts` across the whole monorepo, with `"customConditions": ["power-assert-dev"]`.
+2. In every `exports` map that declares `power-assert-dev` (transpiler-core, transpiler, runtime, node, rollup-plugin-power-assert), list `power-assert-dev` **ahead of** `"types"` within each conditions block. TypeScript resolves the first matching key in declaration order, so this makes the type check bind to workspace sources unconditionally — whether `dist` exists or not.
+3. Wire the check into the everyday commands: `npm run typecheck` (type check alone), `npm run check` (oxlint + `oxfmt --check` + typecheck), `npm test` (check + `test:dev`), and run `npm run check` in CI ahead of the tests.
+
+## Consequences
+
+- Type checking runs on every `npm test` again. Measured on the reference machine: `typecheck` ~0.35s cold, `check` ~0.8s, `npm test` including the full test suite ~1.3s.
+- **The `exports` key order is now load-bearing.** `power-assert-dev` listed ahead of `"types"` looks like a stylistic choice but is an invariant: reordering it back silently downgrades the type check to stale `dist` typings with no error raised — only missing diagnostics. Treat the order as part of the contract when editing `exports` maps, and keep new conditional entry points consistent with it.
+- Runtime and consumer resolution are unchanged. Node.js never matches `"types"`, so development runtime resolution under `--conditions=power-assert-dev` is identical, as is production resolution to `default`. TypeScript consumers of the published packages do not enable the custom condition, skip the `power-assert-dev` key, and resolve `"types"` first exactly as before. ADR-009's analysis of the condition in published tarballs is unaffected.
+- The `power-assert-dev` condition now has two roles: run-from-source at development runtime (ADR-005/ADR-009) and source-resolution for build-free type checking (this ADR). A future rename or removal of the condition must account for both.
+- The type check program is independent of the project-references build (`tsconfig.build.json`), which continues to own emitting and declaration generation for `build:dist`.

--- a/package.json
+++ b/package.json
@@ -28,12 +28,15 @@
     "clean:all": "npm run build:clean --workspaces --if-present",
     "lint": "oxlint packages",
     "fmt": "oxfmt packages",
+    "fmt:check": "oxfmt --check packages",
+    "typecheck": "tsc -p tsconfig.typecheck.json",
+    "check": "npm run lint && npm run fmt:check && npm run typecheck",
     "compile": "tsc --build tsconfig.build.json",
     "build:swc": "npm run test -w swc-plugin-power-assert && npm run build -w swc-plugin-power-assert",
     "test:dist": "node --test --test-reporter=dot 'packages/**/dist/**/*_test.mjs'",
     "test:prove": "prove --exec 'node --conditions=power-assert-dev --test --test-reporter=tap' -r packages --ext=_test.mts",
     "test:dev": "node --conditions=power-assert-dev --test --test-reporter=dot 'packages/**/src/**/__tests__/**/*_test.mts'",
-    "test": "npm run lint && npm run test:dev"
+    "test": "npm run check && npm run test:dev"
   },
   "workspaces": [
     "packages/transpiler-core",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -23,25 +23,25 @@
   "exports": {
     ".": {
       "module-sync": {
-        "types": "./dist/register.d.mts",
         "power-assert-dev": "./src/register.mts",
+        "types": "./dist/register.d.mts",
         "default": "./dist/register.mjs"
       },
       "import": {
-        "types": "./dist/register.d.mts",
         "power-assert-dev": "./src/register.mts",
+        "types": "./dist/register.d.mts",
         "default": "./dist/register.mjs"
       }
     },
     "./hooks": {
       "module-sync": {
-        "types": "./dist/hooks.d.mts",
         "power-assert-dev": "./src/hooks.mts",
+        "types": "./dist/hooks.d.mts",
         "default": "./dist/hooks.mjs"
       },
       "import": {
-        "types": "./dist/hooks.d.mts",
         "power-assert-dev": "./src/hooks.mts",
+        "types": "./dist/hooks.d.mts",
         "default": "./dist/hooks.mjs"
       }
     },

--- a/packages/rollup-plugin-power-assert/package.json
+++ b/packages/rollup-plugin-power-assert/package.json
@@ -29,13 +29,13 @@
   "exports": {
     ".": {
       "module-sync": {
-        "types": "./dist/rollup-plugin-power-assert.d.mts",
         "power-assert-dev": "./src/rollup-plugin-power-assert.mts",
+        "types": "./dist/rollup-plugin-power-assert.d.mts",
         "default": "./dist/rollup-plugin-power-assert.mjs"
       },
       "import": {
-        "types": "./dist/rollup-plugin-power-assert.d.mts",
         "power-assert-dev": "./src/rollup-plugin-power-assert.mts",
+        "types": "./dist/rollup-plugin-power-assert.d.mts",
         "default": "./dist/rollup-plugin-power-assert.mjs"
       }
     },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -28,13 +28,13 @@
   "exports": {
     ".": {
       "module-sync": {
-        "types": "./dist/runtime.d.mts",
         "power-assert-dev": "./src/runtime.mts",
+        "types": "./dist/runtime.d.mts",
         "default": "./dist/runtime.mjs"
       },
       "import": {
-        "types": "./dist/runtime.d.mts",
         "power-assert-dev": "./src/runtime.mts",
+        "types": "./dist/runtime.d.mts",
         "default": "./dist/runtime.mjs"
       }
     },

--- a/packages/transpiler-core/package.json
+++ b/packages/transpiler-core/package.json
@@ -28,13 +28,13 @@
   "exports": {
     ".": {
       "module-sync": {
-        "types": "./dist/transpiler-core.d.mts",
         "power-assert-dev": "./src/transpiler-core.mts",
+        "types": "./dist/transpiler-core.d.mts",
         "default": "./dist/transpiler-core.mjs"
       },
       "import": {
-        "types": "./dist/transpiler-core.d.mts",
         "power-assert-dev": "./src/transpiler-core.mts",
+        "types": "./dist/transpiler-core.d.mts",
         "default": "./dist/transpiler-core.mjs"
       }
     },

--- a/packages/transpiler/package.json
+++ b/packages/transpiler/package.json
@@ -23,13 +23,13 @@
   "exports": {
     ".": {
       "module-sync": {
-        "types": "./dist/transpile-with-sourcemap.d.mts",
         "power-assert-dev": "./src/transpile-with-sourcemap.mts",
+        "types": "./dist/transpile-with-sourcemap.d.mts",
         "default": "./dist/transpile-with-sourcemap.mjs"
       },
       "import": {
-        "types": "./dist/transpile-with-sourcemap.d.mts",
         "power-assert-dev": "./src/transpile-with-sourcemap.mts",
+        "types": "./dist/transpile-with-sourcemap.d.mts",
         "default": "./dist/transpile-with-sourcemap.mjs"
       }
     },

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -2,12 +2,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     // whole-repo type check without building project references:
-    // resolve workspace imports to source .mts files instead of dist typings
-    "paths": {
-      "@power-assert/transpiler-core": ["./packages/transpiler-core/src/transpiler-core.mts"],
-      "@power-assert/transpiler": ["./packages/transpiler/src/transpile-with-sourcemap.mts"],
-      "@power-assert/runtime": ["./packages/runtime/src/runtime.mts"]
-    },
+    // the power-assert-dev condition resolves workspace imports to source
+    // .mts files (each package's exports lists it ahead of "types")
+    "customConditions": ["power-assert-dev"],
     "composite": false,
     "declaration": false,
     "declarationMap": false,

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // whole-repo type check without building project references:
+    // resolve workspace imports to source .mts files instead of dist typings
+    "paths": {
+      "@power-assert/transpiler-core": ["./packages/transpiler-core/src/transpiler-core.mts"],
+      "@power-assert/transpiler": ["./packages/transpiler/src/transpile-with-sourcemap.mts"],
+      "@power-assert/runtime": ["./packages/runtime/src/runtime.mts"]
+    },
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "noEmit": true,
+    "incremental": true,
+    "tsBuildInfoFile": "./node_modules/.cache/tsconfig.typecheck.tsbuildinfo"
+  },
+  "include": ["./packages/*/src/**/*.mts"]
+}


### PR DESCRIPTION
## Motivation

The type stripping migration (ADR-005) made tests fast and frequent,
but deferred type checking to `build:dist` — the only remaining tsc
invocation was the emitting project-references build. With the
toolchain now on oxlint, oxfmt, and TypeScript 7, a whole-repository
static check is cheap enough to run constantly, so type checking
should run as often as lint and tests.

## Changes

- Add `tsconfig.typecheck.json`: a non-composite, noEmit, incremental
  program covering all workspace sources, resolving cross-package
  imports to source `.mts` files via
  `"customConditions": ["power-assert-dev"]` — no build required
- Reorder the `exports` maps of the five packages declaring the
  `power-assert-dev` condition so it is listed ahead of `"types"`.
  TypeScript picks the first matching key in declaration order, so
  this makes the type check bind to workspace sources even when stale
  `dist` typings exist. The key order is now an invariant; Node.js and
  downstream consumers resolve exactly as before
- Add scripts: `typecheck`, `fmt:check`, and `check`
  (lint + format check + type check); `npm test` now runs `check`
  before `test:dev`, and CI runs `npm run check` in place of
  `npm run lint`
- Add ADR-012 recording the decision, the alternatives considered
  (a `paths` mapping, and customConditions without the exports
  reorder — which silently binds to stale dist typings), and the
  key-order invariant:
  `docs/adr-012-build-free-typecheck-via-custom-conditions.md`

## Testing

- A mutation experiment (changing an exported parameter type without
  rebuilding) confirms cross-package call-site errors are reported
  with `dist` present or absent; the unreordered customConditions
  variant misses them when `dist` exists
- `npm run check` finishes in about 0.8s, `npm test` including the
  full test suite in about 1.3s (typecheck alone: about 0.35s cold)
- `npm test`, `npm run build:dist`, and `npm run test:dist` all pass,
  confirming runtime resolution is unchanged by the exports reorder
