### PR TITLE
fix(node): tolerate missing importAttributes on CJS require() path

### DIFF
--- a/docs/adr-007-sync-register-hooks-migration.md
+++ b/docs/adr-007-sync-register-hooks-migration.md
@@ -4,6 +4,8 @@
 
 Accepted
 
+Amended by [ADR-013](./adr-013-sync-hooks-importattributes-hardening.md) — the migration overlooked that sync hooks also intercept CJS `require()` calls, whose load context carries no `importAttributes`; the resulting crash and the shared-context-mutation hazard are addressed there.
+
 ## Context
 
 The `@power-assert/node` package uses Node.js module hooks to intercept and transpile test files at load time. Previously, it relied on `module.register()` to register asynchronous customization hooks (`resolve` and `load`) that ran in a separate loader thread.
@@ -18,6 +20,8 @@ Node.js has deprecated `module.register()` in favor of `module.registerHooks()`,
 | Hook signatures | `async function resolve(...)`, `async function load(...)` | Sync function signatures (`ResolveHookSync`, `LoadHookSync`) |
 | Registration | Indirect — passes a specifier URL to a hooks file | Direct — passes hook function references |
 | I/O in hooks | `await readFile()`, `await transpile()` | `readFileSync()`, `transpileSync()` |
+| CJS `require()` calls | Not intercepted | Intercepted, with a sparser hook context (see [ADR-013](./adr-013-sync-hooks-importattributes-hardening.md)) |
+| Hook context objects | Structured-clone copies in the loader thread — safe to mutate | Shared in-thread objects — mutation is hazardous (see [ADR-013](./adr-013-sync-hooks-importattributes-hardening.md)) |
 | Available since | Node.js 20.6.0 | Node.js 22.15.0 |
 
 ### Development progression

--- a/docs/adr-013-sync-hooks-importattributes-hardening.md
+++ b/docs/adr-013-sync-hooks-importattributes-hardening.md
@@ -1,0 +1,57 @@
+# ADR-013: Defensive `importAttributes` Handling in Sync Module Hooks
+
+## Status
+
+Accepted
+
+Amends [ADR-007](./adr-007-sync-register-hooks-migration.md) (fixes a crash introduced by the sync `module.registerHooks()` migration and hardens the hook implementation it produced).
+
+## Context
+
+ADR-007 replaced async `module.register()` hooks with sync `module.registerHooks()` hooks. One behavioral difference was not accounted for: **sync hooks also intercept CJS `require()` calls**, which the off-thread async hooks never saw.
+
+On that newly-intercepted path, Node.js does not populate `importAttributes` in the load hook context. The `LoadHookContext` type declares the property as required, but at runtime it is `undefined` — a divergence between Node's type declarations and its implementation. The load hook in `@power-assert/node` accessed `context.importAttributes.powerAssert` unconditionally, so from v0.7.0 (the first `registerHooks` release), the first CJS module to `require()` a builtin after hook registration crashed the whole process:
+
+```
+TypeError: Cannot read properties of undefined (reading 'powerAssert')
+    at load (.../@power-assert/node/dist/hooks.mjs:74:27)
+    at loadWithHooks (node:internal/modules/customization_hooks:374:18)
+    at loadBuiltinWithHooks (node:internal/modules/cjs/loader:1239:22)
+    at Object.<anonymous> (.../debug/src/node.js:5:13)   ← require('tty')
+```
+
+The bug was discovered during the same `registerHooks()` migration in mockist-monorepo ([twada/mockist-monorepo#18](https://github.com/twada/mockist-monorepo/pull/18), its ADR-0020), where loading the CJS `debug` package after hook registration killed the process. The package's own test matrix missed it because triggering the crash requires a CJS `require()` executed *for the first time after* registration — existing tests were ESM-centric, and the CJS modules they touched were already cached before hooks were registered.
+
+### A second, related hazard: mutating shared context objects
+
+The same migration left two direct mutations of hook context state:
+
+- the resolve hook injected its marker with `importAttributes.powerAssert = 'power-assert'`, guarded by a MEMO claiming that a spread copy returned from resolve does not propagate to the load context;
+- the load hook removed the marker with `delete importAttributes.powerAssert`.
+
+Under the off-thread async model these mutations touched a structured-clone copy inside the loader thread and were harmless. Under the in-thread sync model the context objects are shared with Node.js internals and with any other registered hooks. The mockist-monorepo migration demonstrated the failure mode concretely: in-thread resolve contexts can be **non-extensible**, so adding a key throws `TypeError: Cannot add property ..., object is not extensible`.
+
+Probing the actual behavior on Node.js v22.20.0, v23.10.0, v24.18.0 and v26.4.0 established two facts:
+
+1. An `importAttributes` object newly created in the resolve hook and returned in its result **does** reach the load hook context on all four lines — the MEMO's claim no longer holds.
+2. The default load step rejects unknown import attributes (`ERR_IMPORT_ATTRIBUTE_UNSUPPORTED`), which is why the marker must be removed before delegating to `nextLoad` — the `delete` had been doing necessary work, just on the wrong object.
+
+## Decision
+
+1. **Normalize before access.** Both hooks read `importAttributes` as `context.importAttributes ?? {}` and never access a property on the raw context value. This makes the CJS `require()` path a clean pass-through.
+2. **Communicate the marker via copies, never by mutation.** The resolve hook returns an *augmented copy* (`{ ...importAttributes, powerAssert: 'power-assert' }`) in its result; the load hook passes a *cleansed copy* (marker removed via rest destructuring) to `nextLoad`. No hook context object is mutated.
+3. **Regression test at the process level.** A test spawns `node --import @power-assert/node --eval "require('tty')"` — `--eval` code is CJS, so the `require()` traverses the registered sync hooks — and asserts a clean exit. It runs against both development sources and compiled `dist` output, closing the "first post-registration CJS require" gap in the matrix.
+
+## Consequences
+
+- CJS `require()` after hook registration no longer crashes. CJS modules are still not instrumented (unchanged policy — only entry-point test files are transformed); the hooks now simply delegate for them.
+- The failure mode for a missing-attributes edge case degrades from process crash to "transform silently skipped", which the package's output-asserting tests would catch on any affected Node.js line.
+- The powerAssert marker remains a cross-hook coupling carried through `importAttributes`. The contract is now explicit: resolve adds the marker on a copy it returns; load must remove it (again on a copy) before delegating, because default load validates attributes.
+- The propagation probe covered v22.20.0 but not v22.15.0–v22.19.x (not installed locally). If an early 22.x sync-hooks implementation failed to propagate resolve-returned copies, the symptom would be the silent-skip mode above, not a crash.
+- Node's `LoadHookContext` type declaring `importAttributes` as required while the CJS path omits it is an upstream type/implementation divergence; the normalization makes this package robust regardless of whether Node fixes the type or the implementation.
+
+## References
+
+- `module.registerHooks()` API (intercepts both ESM `import` and CJS `require()`): https://nodejs.org/api/module.html#moduleregisterhooksoptions
+- Discovery context: [twada/mockist-monorepo#18](https://github.com/twada/mockist-monorepo/pull/18) and its ADR-0020 (replace async module.register with sync registerHooks)
+- [ADR-007](./adr-007-sync-register-hooks-migration.md): the migration that introduced the sync hooks

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -79,6 +79,7 @@
     "demo": "node --conditions=power-assert-dev --enable-source-maps --import @power-assert/node --test examples/demo.test.mjs",
     "test:js": "node --conditions=power-assert-dev --enable-source-maps --import @power-assert/node --test examples/bowling.test.mjs | grep 'examples/bowling.test.mjs:110:7'",
     "test:ts": "node --conditions=power-assert-dev --experimental-strip-types --enable-source-maps --import @power-assert/node --test examples/bowling.test.mts | grep 'examples/bowling.test.mts:114:7'",
-    "test": "npm run test:js && npm run test:ts"
+    "test:hooks": "node --conditions=power-assert-dev --test 'src/**/__tests__/**/*test.mts'",
+    "test": "npm run test:js && npm run test:ts && npm run test:hooks"
   }
 }

--- a/packages/node/src/__tests__/hooks_test.mts
+++ b/packages/node/src/__tests__/hooks_test.mts
@@ -1,0 +1,25 @@
+import { describe, test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(__dirname, '..', '..');
+
+describe('sync hooks registered via module.registerHooks', () => {
+  // Unlike module.register(), sync hooks also intercept CJS require() calls.
+  // On that path Node.js does not provide `importAttributes` in the load context,
+  // so hooks must not assume its presence.
+  // see: https://github.com/twada/power-assert-monorepo/blob/main/docs/adr-013-importattributes-normalization-on-cjs-require-path.md
+  test('CJS require() of a builtin module after hooks registration does not crash', () => {
+    const args: string[] = [];
+    if (process.execArgv.includes('--conditions=power-assert-dev')) {
+      args.push('--conditions=power-assert-dev');
+    }
+    // `--eval` runs as CJS, so require('tty') goes through the registered sync hooks
+    args.push('--import', '@power-assert/node', '--eval', "require('tty')");
+    const result = spawnSync(process.execPath, args, { cwd: packageRoot, encoding: 'utf8' });
+    assert.equal(result.status, 0, `child process should exit cleanly but got status ${result.status}\nstderr: ${result.stderr}`);
+  });
+});

--- a/packages/node/src/__tests__/hooks_test.mts
+++ b/packages/node/src/__tests__/hooks_test.mts
@@ -11,7 +11,7 @@ describe('sync hooks registered via module.registerHooks', () => {
   // Unlike module.register(), sync hooks also intercept CJS require() calls.
   // On that path Node.js does not provide `importAttributes` in the load context,
   // so hooks must not assume its presence.
-  // see: https://github.com/twada/power-assert-monorepo/blob/main/docs/adr-013-importattributes-normalization-on-cjs-require-path.md
+  // see: https://github.com/twada/power-assert-monorepo/blob/main/docs/adr-013-sync-hooks-importattributes-hardening.md
   test('CJS require() of a builtin module after hooks registration does not crash', () => {
     const args: string[] = [];
     if (process.execArgv.includes('--conditions=power-assert-dev')) {

--- a/packages/node/src/hooks.mts
+++ b/packages/node/src/hooks.mts
@@ -52,7 +52,8 @@ export const resolve: ResolveHookSync = function resolve(specifier: string, cont
   if (!isModule) {
     return nextResolveWithShortCircuitFalse(specifier, context);
   }
-  const { importAttributes } = context;
+  // importAttributes is missing from the context on the CJS require() path that sync hooks also intercept
+  const importAttributes = context.importAttributes ?? {};
   // MEMO: need to mutate importAttributes directly since shallow copy of importAttributes with object rest spread operator does not work in this case
   importAttributes.powerAssert = 'power-assert';
   // const extraAttrs = { powerAssert: 'power-assert' };
@@ -81,7 +82,9 @@ export const load: LoadHookSync = function load(url: string, context: LoadHookCo
     const loaded = nextLoad(url, context);
     return { ...loaded, shortCircuit: false };
   };
-  const { importAttributes, format } = context;
+  const { format } = context;
+  // importAttributes is missing from the context on the CJS require() path that sync hooks also intercept
+  const importAttributes = context.importAttributes ?? {};
   if (!importAttributes.powerAssert) {
     return nextLoadWithShortCircuitFalse(url, context);
   }

--- a/packages/node/src/hooks.mts
+++ b/packages/node/src/hooks.mts
@@ -54,13 +54,10 @@ export const resolve: ResolveHookSync = function resolve(specifier: string, cont
   }
   // importAttributes is missing from the context on the CJS require() path that sync hooks also intercept
   const importAttributes = context.importAttributes ?? {};
-  // MEMO: need to mutate importAttributes directly since shallow copy of importAttributes with object rest spread operator does not work in this case
-  importAttributes.powerAssert = 'power-assert';
-  // const extraAttrs = { powerAssert: 'power-assert' };
+  // in-thread sync hook contexts are shared objects and can be non-extensible, so augment a copy instead of mutating the original
   const resolved: ResolveFnOutput = {
     format: format === 'module-typescript' ? 'module-typescript' : 'module',
-    // importAttributes: { ...importAttributes, ...extraAttrs },
-    importAttributes,
+    importAttributes: { ...importAttributes, powerAssert: 'power-assert' },
     shortCircuit: false,
     url
   };
@@ -88,9 +85,9 @@ export const load: LoadHookSync = function load(url: string, context: LoadHookCo
   if (!importAttributes.powerAssert) {
     return nextLoadWithShortCircuitFalse(url, context);
   }
-  delete importAttributes.powerAssert;
-
-  const { source: rawSource } = nextLoadWithShortCircuitFalse(url, context);
+  // default load rejects unknown import attributes, so pass a cleansed copy downstream instead of deleting from the shared context
+  const { powerAssert: _powerAssert, ...cleansedAttributes } = importAttributes;
+  const { source: rawSource } = nextLoadWithShortCircuitFalse(url, { ...context, importAttributes: cleansedAttributes });
   assert(rawSource !== undefined, 'rawSource should not be undefined');
   let incomingCode = rawSource.toString();
   if (format === 'module-typescript') {


### PR DESCRIPTION
## Summary

Sync hooks registered via module.registerHooks() also intercept CJS
require() calls, unlike the former async module.register() hooks. On
that path Node.js provides no `importAttributes` in the hook contexts —
the LoadHookContext type declares the property as required, but at
runtime it is undefined. The load hook accessed
`context.importAttributes.powerAssert` unconditionally, so from v0.7.0
the first CJS module to require a builtin after hook registration
crashed the whole process:

    TypeError: Cannot read properties of undefined (reading 'powerAssert')
        at load (.../@power-assert/node/dist/hooks.mjs:74:27)
        at loadBuiltinWithHooks (node:internal/modules/cjs/loader:1239:22)
        at Object.<anonymous> (.../debug/src/node.js:5:13)   <- require('tty')

Discovered during the same registerHooks() migration in
mockist-monorepo, where loading the CJS debug package after hook
registration killed the process.

Minimal reproduction (crashes on 0.7.x, exits cleanly with this change):

    node --import @power-assert/node --eval "require('tty')"

## Changes

- Both hooks normalize with `context.importAttributes ?? {}` before any
  property access, making the CJS require() path a clean pass-through.
- Hardening in the same class: the hooks no longer mutate the shared
  in-thread context objects. The resolve hook returns an augmented copy
  of importAttributes carrying the powerAssert marker, and the load hook
  passes a cleansed copy (marker removed) to nextLoad, since the default
  load step rejects unknown import attributes. In-thread resolve
  contexts can be non-extensible, so the previous direct mutation was a
  latent TypeError of its own class.
- The removed MEMO claimed a spread copy returned from resolve does not
  propagate to the load context. Probing Node.js v22.20.0, v22.23.2,
  v23.10.0, v24.18.0, v24.20.0, v26.4.0 and v26.8.1 shows
  resolve-returned copies reach the load hook on all lines, so the
  justification for mutation is stale.
- ADR-013 records the decision; ADR-007 is amended with the two
  behavioral differences of module.registerHooks() the migration
  overlooked.

## Testing

- New process-level regression test spawns the minimal reproduction
  above (`--eval` code is CJS, so the require() traverses the
  registered sync hooks) and asserts a clean exit. It fails with the
  TypeError above without the fix, and runs against both development
  sources and compiled dist output. The package's matrix had this gap
  because triggering the crash needs a CJS require() executed for the
  first time after registration — existing tests were ESM-centric or
  had their CJS modules cached before registration.
- Full suite green: check (lint, format, typecheck), test:dev, compile,
  test:dist.

## References

Discovery context:
https://github.com/twada/mockist-monorepo/pull/18

ADR:
docs/adr-013-sync-hooks-importattributes-hardening.md

