### PR TITLE
ci: add Node.js 26 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
## Summary

Add Node.js 26.x to the CI test matrix alongside 22.x and 24.x.

## Motivation

Node.js 26 is the current release line. Running the test suite on it
in CI catches loader, test runner, and module resolution behavior
changes early, before users on Node 26 report them.

## Changes

- `.github/workflows/ci.yml`: extend `node-version` matrix with `26.x`

The release workflow keeps its pinned Node 24 and is not affected.
The only package with an `engines` field, `@power-assert/node`, already
declares `node >=22.15.0`, so no
package metadata change is needed.
